### PR TITLE
Port object flow fusion

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,4 +43,20 @@ jobs:
         . /opt/ros/foxy/setup.sh
         colcon test \
           --event-handlers console_cohesion+ \
-          --return-code-on-test-failure
+          --return-code-on-test-failure \
+          --packages-skip \
+            tf2_msgs \
+            tf2_kdl \
+            tf2_py \
+            geometry2 \
+            test_tf2 \
+            tf2_eigen \
+            tf2_ros \
+            tf2_tools \
+            tf2_sensor_msgs \
+            tf2_geometry_msgs \
+            geometry_experimental \
+            tf2_bullet \
+            examples_tf2_py \
+            tf2
+          # Skip geometry2 packages until they are released

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,20 +43,4 @@ jobs:
         . /opt/ros/foxy/setup.sh
         colcon test \
           --event-handlers console_cohesion+ \
-          --return-code-on-test-failure \
-          --packages-skip \
-            tf2_msgs \
-            tf2_kdl \
-            tf2_py \
-            geometry2 \
-            test_tf2 \
-            tf2_eigen \
-            tf2_ros \
-            tf2_tools \
-            tf2_sensor_msgs \
-            tf2_geometry_msgs \
-            geometry_experimental \
-            tf2_bullet \
-            examples_tf2_py \
-            tf2
-          # Skip geometry2 packages until they are released
+          --return-code-on-test-failure

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -15,9 +15,3 @@ repositories:
     type: git
     url: https://github.com/ApexAI/topic_tools.git
     version: autoware
-  # temporary adding geometry2 package to add support for transforming covariance
-  # TODO(esteve): remove after geometry2 package is released in Foxy anytime after 2020/12/12
-  vendor/geometry2:
-    type: git
-    url: https://github.com/ros2/geometry2.git
-    version: foxy

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -15,3 +15,9 @@ repositories:
     type: git
     url: https://github.com/ApexAI/topic_tools.git
     version: autoware
+  # temporary adding geometry2 package to add support for transforming covariance
+  # TODO(esteve): remove after geometry2 package is released in Foxy anytime after 2020/12/12
+  vendor/geometry2:
+    type: git
+    url: https://github.com/ros2/geometry2.git
+    version: foxy

--- a/perception/object_recognition/detection/bev_optical_flow/src/utils.cpp
+++ b/perception/object_recognition/detection/bev_optical_flow/src/utils.cpp
@@ -16,6 +16,7 @@
 #include "tf2/LinearMath/Matrix3x3.h"
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_eigen/tf2_eigen.h"
 
 namespace bev_optical_flow
 {
@@ -80,7 +81,7 @@ geometry_msgs::Twist Utils::getObjCoordsTwist(
   const geometry_msgs::Twist & base_coords_twist)
 {
   Eigen::Affine3d base2obj_transform;
-  tf::poseMsgToEigen(obj_pose, base2obj_transform);
+  tf2::convert(obj_pose, base2obj_transform);
   Eigen::Matrix3d base2obj_rot = base2obj_transform.rotation();
   Eigen::Vector3d obj_coords_vector =
     base2obj_rot.inverse() * Eigen::Vector3d(

--- a/perception/object_recognition/detection/object_flow_fusion/CMakeLists.txt
+++ b/perception/object_recognition/detection/object_flow_fusion/CMakeLists.txt
@@ -1,19 +1,16 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(object_flow_fusion)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+## Compile as C++14, supported in ROS Melodic and newer
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  rospy
-  geometry_msgs
-  sensor_msgs
-  pcl_conversions
-  pcl_ros
-  tf
-  autoware_perception_msgs
-  eigen_conversions
-  )
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 find_package(OpenCV REQUIRED)
 find_package(Eigen3 REQUIRED)
@@ -25,38 +22,13 @@ include_directories(
   ${EIGEN3_INCLUDE_DIRS}
   )
 
-add_definitions(-std=c++14)
-
-catkin_package(
-  INCLUDE_DIRS
-  include
-  CATKIN_DEPENDS
-  LIBRARIES ${PROJECT_NAME}
-)
-
-add_executable(object_flow_fusion_node
+ament_auto_add_executable(object_flow_fusion_node
   src/main.cpp
   src/node.cpp
   src/object_flow_fusion.cpp
   src/utils.cpp
   )
-target_link_libraries(object_flow_fusion_node
-  ${catkin_LIBRARIES}
-  ${OpenCV_LIBRARIES}
-  )
 
-install(
-  TARGETS
-  object_flow_fusion_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  )
-
-install(DIRECTORY launch/
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
-  )
-
-install(DIRECTORY include/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/${PROJECT_NAME}/
-  )
+ament_auto_package(INSTALL_TO_SHARE
+  launch
+)

--- a/perception/object_recognition/detection/object_flow_fusion/include/object_flow_fusion/node.hpp
+++ b/perception/object_recognition/detection/object_flow_fusion/include/object_flow_fusion/node.hpp
@@ -16,42 +16,40 @@
 
 #include <iostream>
 
-#include "ros/ros.h"
+#include "rclcpp/rclcpp.hpp"
 #include "message_filters/subscriber.h"
 #include "message_filters/time_synchronizer.h"
 #include "message_filters/synchronizer.h"
 #include "message_filters/sync_policies/approximate_time.h"
-#include "autoware_perception_msgs/DynamicObjectWithFeatureArray.h"
+#include "autoware_perception_msgs/msg/dynamic_object_with_feature_array.hpp"
 #include "object_flow_fusion.h"
 
 namespace object_flow_fusion
 {
-class ObjectFlowFusionNode
+class ObjectFlowFusionNode : public rclcpp::Node
 {
 public:
   ObjectFlowFusionNode();
   void callback(
-    const autoware_perception_msgs::DynamicObjectWithFeatureArray::ConstPtr& object_msg,
-    const autoware_perception_msgs::DynamicObjectWithFeatureArray::ConstPtr& flow_msg);
+    const autoware_perception_msgs::msg::DynamicObjectWithFeatureArray::ConstPtr& object_msg,
+    const autoware_perception_msgs::msg::DynamicObjectWithFeatureArray::ConstPtr& flow_msg);
 private:
   typedef message_filters::sync_policies::ApproximateTime<
-  autoware_perception_msgs::DynamicObjectWithFeatureArray,
-  autoware_perception_msgs::DynamicObjectWithFeatureArray
+  autoware_perception_msgs::msg::DynamicObjectWithFeatureArray,
+  autoware_perception_msgs::msg::DynamicObjectWithFeatureArray
   > ApproximateSync;
 
   typedef message_filters::sync_policies::ExactTime<
-    autoware_perception_msgs::DynamicObjectWithFeatureArray,
-    autoware_perception_msgs::DynamicObjectWithFeatureArray
+    autoware_perception_msgs::msg::DynamicObjectWithFeatureArray,
+    autoware_perception_msgs::msg::DynamicObjectWithFeatureArray
     > Sync;
 
-  boost::shared_ptr<message_filters::Synchronizer<ApproximateSync> > approximate_sync_;
-  boost::shared_ptr<message_filters::Synchronizer<Sync> > sync_;
-  message_filters::Subscriber<autoware_perception_msgs::DynamicObjectWithFeatureArray> object_sub_;
-  message_filters::Subscriber<autoware_perception_msgs::DynamicObjectWithFeatureArray> flow_sub_;
+  std::shared_ptr<message_filters::Synchronizer<ApproximateSync> > approximate_sync_;
+  std::shared_ptr<message_filters::Synchronizer<Sync> > sync_;
+  message_filters::Subscriber<autoware_perception_msgs::msg::DynamicObjectWithFeatureArray> object_sub_;
+  message_filters::Subscriber<autoware_perception_msgs::msg::DynamicObjectWithFeatureArray> flow_sub_;
 
-  ros::NodeHandle nh_;
-  ros::NodeHandle pnh_;
-  ros::Publisher pub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DynamicObjectWithFeatureArray>::SharedPtr pub_;
   bool is_approximate_sync_;
   bool use_flow_pose_;
   float flow_vel_thresh_;

--- a/perception/object_recognition/detection/object_flow_fusion/include/object_flow_fusion/node.hpp
+++ b/perception/object_recognition/detection/object_flow_fusion/include/object_flow_fusion/node.hpp
@@ -22,7 +22,7 @@
 #include "message_filters/synchronizer.h"
 #include "message_filters/sync_policies/approximate_time.h"
 #include "autoware_perception_msgs/msg/dynamic_object_with_feature_array.hpp"
-#include "object_flow_fusion.h"
+#include "object_flow_fusion.hpp"
 
 namespace object_flow_fusion
 {

--- a/perception/object_recognition/detection/object_flow_fusion/include/object_flow_fusion/object_flow_fusion.hpp
+++ b/perception/object_recognition/detection/object_flow_fusion/include/object_flow_fusion/object_flow_fusion.hpp
@@ -16,55 +16,74 @@
 
 #include <iostream>
 #include <math.h>
-#include "ros/ros.h"
-#include "autoware_perception_msgs/DynamicObjectWithFeatureArray.h"
+#include "rclcpp/rclcpp.hpp"
+#include "autoware_perception_msgs/msg/dynamic_object_with_feature_array.hpp"
 #include "pcl_conversions/pcl_conversions.h"
-#include "eigen_conversions/eigen_msg.h"
+// #include "eigen_conversions/eigen_msg.h"
 #include "opencv2/core/core.hpp"
 #include "opencv2/highgui/highgui.hpp"
 #include "opencv2/imgproc/imgproc.hpp"
-#include "utils.h"
+#include "utils.hpp"
 
 namespace object_flow_fusion
 {
-class ObjectFlowFusion
+class ObjectFlowFusion : public rclcpp::Node
 {
 public:
   ObjectFlowFusion();
   void fusion(
-    const autoware_perception_msgs::DynamicObjectWithFeatureArray::ConstPtr& object_msg,
-    const autoware_perception_msgs::DynamicObjectWithFeatureArray::ConstPtr& flow_msg,
+    const autoware_perception_msgs::msg::DynamicObjectWithFeatureArray::ConstPtr& object_msg,
+    const autoware_perception_msgs::msg::DynamicObjectWithFeatureArray::ConstPtr& flow_msg,
     bool use_flow_pose, float flow_vel_thresh_,
-    autoware_perception_msgs::DynamicObjectWithFeatureArray& fusioned_msg);
+    autoware_perception_msgs::msg::DynamicObjectWithFeatureArray& fusioned_msg);
 private:
 
   bool getPolygon(
-    const autoware_perception_msgs::DynamicObject& object,
-    const geometry_msgs::Polygon& input_footprint,
-    geometry_msgs::Polygon& output_footprint);
+    const autoware_perception_msgs::msg::DynamicObject& object,
+    const geometry_msgs::msg::Polygon& input_footprint,
+    geometry_msgs::msg::Polygon& output_footprint);
 
   bool isInsidePolygon(
-    const geometry_msgs::Pose& pose,
-    const geometry_msgs::Polygon& footprint,
-    const geometry_msgs::Point& flow_point);
+    const geometry_msgs::msg::Pose& pose,
+    const geometry_msgs::msg::Polygon& footprint,
+    const geometry_msgs::msg::Point& flow_point);
 
   bool isInsideCylinder(
-    const geometry_msgs::Pose& pose,
-    const autoware_perception_msgs::Shape& shape,
-    const geometry_msgs::Point& flow_point);
+    const geometry_msgs::msg::Pose& pose,
+    const autoware_perception_msgs::msg::Shape& shape,
+    const geometry_msgs::msg::Point& flow_point);
 
   bool isInsideShape(
-    const autoware_perception_msgs::DynamicObject& object,
-    const geometry_msgs::Point& flow_point,
-    const geometry_msgs::Polygon& footprint);
+    const autoware_perception_msgs::msg::DynamicObject& object,
+    const geometry_msgs::msg::Point& flow_point,
+    const geometry_msgs::msg::Polygon& footprint);
 
-  geometry_msgs::Twist getLocalTwist(
-    const geometry_msgs::Pose& obj_pose, const geometry_msgs::Twist& base_coords_twist);
+  geometry_msgs::msg::Twist getLocalTwist(
+    const geometry_msgs::msg::Pose& obj_pose, const geometry_msgs::msg::Twist& base_coords_twist);
 
-  ros::NodeHandle nh_;
-  ros::NodeHandle pnh_;
   float point_radius_;
   std::shared_ptr<Utils> utils_;
   float fusion_box_offset_;
+
+  // NOTE(esteve): copied from eigen_conversions
+  void pointMsgToEigen(const geometry_msgs::msg::Point &m, Eigen::Vector3d &e);
+
+  // NOTE(esteve): copied from eigen_conversions
+  void poseMsgToEigen(const geometry_msgs::msg::Pose &m, Eigen::Affine3d &e);
+
+  // NOTE(esteve): copied from eigen_conversions
+  void quaternionEigenToMsg(const Eigen::Quaterniond &e, geometry_msgs::msg::Quaternion &m);
+
+  template<typename T>
+  void poseMsgToEigenImpl(const geometry_msgs::msg::Pose &m, T &e)
+  {
+    e = Eigen::Translation3d(m.position.x,
+                             m.position.y,
+                             m.position.z) *
+      Eigen::Quaterniond(m.orientation.w,
+                         m.orientation.x,
+                         m.orientation.y,
+                         m.orientation.z);
+  }
 };
 } // object_flow_fusion

--- a/perception/object_recognition/detection/object_flow_fusion/include/object_flow_fusion/object_flow_fusion.hpp
+++ b/perception/object_recognition/detection/object_flow_fusion/include/object_flow_fusion/object_flow_fusion.hpp
@@ -64,26 +64,5 @@ private:
   float point_radius_;
   std::shared_ptr<Utils> utils_;
   float fusion_box_offset_;
-
-  // NOTE(esteve): copied from eigen_conversions
-  void pointMsgToEigen(const geometry_msgs::msg::Point &m, Eigen::Vector3d &e);
-
-  // NOTE(esteve): copied from eigen_conversions
-  void poseMsgToEigen(const geometry_msgs::msg::Pose &m, Eigen::Affine3d &e);
-
-  // NOTE(esteve): copied from eigen_conversions
-  void quaternionEigenToMsg(const Eigen::Quaterniond &e, geometry_msgs::msg::Quaternion &m);
-
-  template<typename T>
-  void poseMsgToEigenImpl(const geometry_msgs::msg::Pose &m, T &e)
-  {
-    e = Eigen::Translation3d(m.position.x,
-                             m.position.y,
-                             m.position.z) *
-      Eigen::Quaterniond(m.orientation.w,
-                         m.orientation.x,
-                         m.orientation.y,
-                         m.orientation.z);
-  }
 };
 } // object_flow_fusion

--- a/perception/object_recognition/detection/object_flow_fusion/include/object_flow_fusion/utils.hpp
+++ b/perception/object_recognition/detection/object_flow_fusion/include/object_flow_fusion/utils.hpp
@@ -16,11 +16,11 @@
 
 #include "opencv2/highgui/highgui.hpp"
 #include "opencv2/core/core.hpp"
-#include "geometry_msgs/TwistStamped.h"
-#include "autoware_perception_msgs/DynamicObjectWithFeatureArray.h"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "autoware_perception_msgs/msg/dynamic_object_with_feature_array.hpp"
 #include "tf2_ros/transform_listener.h"
 #include "tf2_eigen/tf2_eigen.h"
-#include "eigen_conversions/eigen_msg.h"
+// #include "eigen_conversions/eigen_msg.h"
 
 namespace object_flow_fusion
 {
@@ -28,13 +28,13 @@ class Utils
 {
 public:
   Utils() {};
-  geometry_msgs::Vector3 mptopic2kph(
-    const geometry_msgs::Vector3& twist,
+  geometry_msgs::msg::Vector3 mptopic2kph(
+    const geometry_msgs::msg::Vector3& twist,
     double topic_rate);
-  geometry_msgs::Vector3 kph2mptopic(
-    const geometry_msgs::Vector3& twist,
+  geometry_msgs::msg::Vector3 kph2mptopic(
+    const geometry_msgs::msg::Vector3& twist,
     double topic_rate);
-  geometry_msgs::Vector3 kph2mps(const geometry_msgs::Vector3& twist);
-  geometry_msgs::Twist kph2mps(const geometry_msgs::Twist& twist);
+  geometry_msgs::msg::Vector3 kph2mps(const geometry_msgs::msg::Vector3& twist);
+  geometry_msgs::msg::Twist kph2mps(const geometry_msgs::msg::Twist& twist);
 };
 } // object_flow_fusion

--- a/perception/object_recognition/detection/object_flow_fusion/package.xml
+++ b/perception/object_recognition/detection/object_flow_fusion/package.xml
@@ -1,33 +1,27 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>object_flow_fusion</name>
   <version>0.1.0</version>
   <description>The object_flow_fusion package</description>
 
   <maintainer email="taichi.higashide@tier4.jp">Taichi Higashide</maintainer>
-  <license>Apache2</license>
+  <license>Apache License 2.0</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>pcl_conversions</build_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>autoware_perception_msgs</build_depend>
-  <build_depend>eigen_conversions</build_depend>
-
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>pcl_conversions</exec_depend>
-  <exec_depend>pcl_ros</exec_depend>
-  <exec_depend>tf</exec_depend>
-  <exec_depend>autoware_perception_msgs</exec_depend>
-  <exec_depend>eigen_conversions</exec_depend>
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
+  <depend>tf2</depend>
+  <depend>autoware_perception_msgs</depend>
+  <!-- <depend>eigen_conversions</depend> -->
 
   <export>
+    <build_type>ament_cmake</build_type>
   </export>
 
 </package>

--- a/perception/object_recognition/detection/object_flow_fusion/package.xml
+++ b/perception/object_recognition/detection/object_flow_fusion/package.xml
@@ -17,6 +17,7 @@
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
   <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
   <depend>autoware_perception_msgs</depend>
   <!-- <depend>eigen_conversions</depend> -->
 

--- a/perception/object_recognition/detection/object_flow_fusion/src/main.cpp
+++ b/perception/object_recognition/detection/object_flow_fusion/src/main.cpp
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ros/ros.h"
+#include "rclcpp/rclcpp.hpp"
 #include "object_flow_fusion/node.hpp"
 
 int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "object_flow_fusion");
-  object_flow_fusion::ObjectFlowFusionNode optical_flow_node;
-  ros::spin();
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<object_flow_fusion::ObjectFlowFusionNode>());
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/perception/object_recognition/detection/object_flow_fusion/src/node.cpp
+++ b/perception/object_recognition/detection/object_flow_fusion/src/node.cpp
@@ -12,41 +12,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <functional>
+
 #include "object_flow_fusion/node.hpp"
 
 namespace object_flow_fusion
 {
-ObjectFlowFusionNode::ObjectFlowFusionNode() : nh_(""), pnh_("~")
+ObjectFlowFusionNode::ObjectFlowFusionNode()
+: Node("object_flow_fusion")
 {
-  pnh_.param<bool>("is_approximate_sync", is_approximate_sync_, true);
-  pnh_.param<bool>("use_flow_pose", use_flow_pose_, true);
-  pnh_.param<float>("flow_vel_thresh", flow_vel_thresh_, 10.0);
+  using std::placeholders::_1;
+  using std::placeholders::_2;
 
-  object_sub_.subscribe(pnh_, "input_object", 1);
-  flow_sub_.subscribe(pnh_, "input_flow", 1);
+  is_approximate_sync_ = declare_parameter("is_approximate_sync", true);
+  use_flow_pose_ = declare_parameter("use_flow_pose", true);
+  flow_vel_thresh_ = declare_parameter<float>("flow_vel_thresh", 10.0);
+
+  object_sub_.subscribe(this, "input_object", rclcpp::QoS{1}.get_rmw_qos_profile());
+  flow_sub_.subscribe(this, "input_flow", rclcpp::QoS{1}.get_rmw_qos_profile());
 
   if (is_approximate_sync_) {
-    approximate_sync_ = boost::make_shared<message_filters::Synchronizer<ApproximateSync> >(1000);
+    approximate_sync_ = std::make_shared<message_filters::Synchronizer<ApproximateSync> >(1000);
     approximate_sync_->connectInput(object_sub_, flow_sub_);
-    approximate_sync_->registerCallback(boost::bind(&ObjectFlowFusionNode::callback, this, _1, _2));
+    approximate_sync_->registerCallback(std::bind(&ObjectFlowFusionNode::callback, this, _1, _2));
   } else {
-    sync_  = boost::make_shared<message_filters::Synchronizer<Sync> >(1000);
+    sync_  = std::make_shared<message_filters::Synchronizer<Sync> >(1000);
     sync_->connectInput(object_sub_, flow_sub_);
-    sync_->registerCallback(boost::bind(&ObjectFlowFusionNode::callback, this, _1, _2));
+    sync_->registerCallback(std::bind(&ObjectFlowFusionNode::callback, this, _1, _2));
   }
 
-  pub_ = pnh_.advertise<autoware_perception_msgs::DynamicObjectWithFeatureArray>("output", 1);
+  pub_ = create_publisher<autoware_perception_msgs::msg::DynamicObjectWithFeatureArray>("output", rclcpp::QoS{1});
   object_flow_fusion_ = std::make_shared<ObjectFlowFusion>();
 }
 
 void ObjectFlowFusionNode::callback(
-  const autoware_perception_msgs::DynamicObjectWithFeatureArray::ConstPtr& object_msg,
-  const autoware_perception_msgs::DynamicObjectWithFeatureArray::ConstPtr& flow_msg)
+  const autoware_perception_msgs::msg::DynamicObjectWithFeatureArray::ConstPtr& object_msg,
+  const autoware_perception_msgs::msg::DynamicObjectWithFeatureArray::ConstPtr& flow_msg)
 {
-  autoware_perception_msgs::DynamicObjectWithFeatureArray fused_msg;
+  autoware_perception_msgs::msg::DynamicObjectWithFeatureArray fused_msg;
   fused_msg.header = object_msg->header;
   object_flow_fusion_->fusion(object_msg, flow_msg, use_flow_pose_, flow_vel_thresh_, fused_msg);
-  pub_.publish(fused_msg);
+  pub_->publish(fused_msg);
 }
 
 } // object_flow_fusion_node

--- a/perception/object_recognition/detection/object_flow_fusion/src/object_flow_fusion.cpp
+++ b/perception/object_recognition/detection/object_flow_fusion/src/object_flow_fusion.cpp
@@ -13,20 +13,21 @@
 // limitations under the License.
 
 #include "object_flow_fusion/object_flow_fusion.hpp"
-#include "eigen_conversions/eigen_msg.h"
+// #include "eigen_conversions/eigen_msg.h"
 
 namespace object_flow_fusion
 {
-ObjectFlowFusion::ObjectFlowFusion() : nh_(""), pnh_("~")
+ObjectFlowFusion::ObjectFlowFusion()
+: rclcpp::Node("object_flow_fusion")
 {
-  pnh_.param<float>("fusion_box_offset", fusion_box_offset_, 0.1);
+  fusion_box_offset_ = declare_parameter<float>("fusion_box_offset", 0.1);
   utils_ = std::make_shared<Utils>();
 }
 
 bool ObjectFlowFusion::isInsidePolygon(
-  const geometry_msgs::Pose& pose,
-  const geometry_msgs::Polygon& footprint,
-  const geometry_msgs::Point& flow_point)
+  const geometry_msgs::msg::Pose& pose,
+  const geometry_msgs::msg::Polygon& footprint,
+  const geometry_msgs::msg::Point& flow_point)
 {
   double formed_angle_sum = 0;
   Eigen::Vector2d flow_point2d(flow_point.x, flow_point.y);
@@ -58,14 +59,14 @@ bool ObjectFlowFusion::isInsidePolygon(
 }
 
 bool ObjectFlowFusion::isInsideCylinder(
-  const geometry_msgs::Pose& pose,
-  const autoware_perception_msgs::Shape& shape,
-  const geometry_msgs::Point& flow_point)
+  const geometry_msgs::msg::Pose& pose,
+  const autoware_perception_msgs::msg::Shape& shape,
+  const geometry_msgs::msg::Point& flow_point)
 {
   Eigen::Affine3d base2obj_transform;
-  tf::poseMsgToEigen(pose, base2obj_transform);
+  poseMsgToEigen(pose, base2obj_transform);
   Eigen::Vector3d eigen_flow_point;
-  tf::pointMsgToEigen(flow_point, eigen_flow_point);
+  pointMsgToEigen(flow_point, eigen_flow_point);
   auto local_eigen_flow_point = base2obj_transform.inverse() * eigen_flow_point;
 
   double radius = shape.dimensions.x;
@@ -76,17 +77,17 @@ bool ObjectFlowFusion::isInsideCylinder(
 }
 
 bool ObjectFlowFusion::isInsideShape(
-  const autoware_perception_msgs::DynamicObject& object,
-  const geometry_msgs::Point& flow_point,
-  const geometry_msgs::Polygon& footprint)
+  const autoware_perception_msgs::msg::DynamicObject& object,
+  const geometry_msgs::msg::Point& flow_point,
+  const geometry_msgs::msg::Polygon& footprint)
 {
-  geometry_msgs::Pose pose = object.state.pose_covariance.pose;
-  autoware_perception_msgs::Shape shape = object.shape;
+  geometry_msgs::msg::Pose pose = object.state.pose_covariance.pose;
+  autoware_perception_msgs::msg::Shape shape = object.shape;
 
-  if ( shape.type == autoware_perception_msgs::Shape::POLYGON ||
-    shape.type == autoware_perception_msgs::Shape::BOUNDING_BOX ) {
+  if ( shape.type == autoware_perception_msgs::msg::Shape::POLYGON ||
+    shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX ) {
     return isInsidePolygon(pose, footprint, flow_point);
-  } else if ( shape.type == autoware_perception_msgs::Shape::CYLINDER ) {
+  } else if ( shape.type == autoware_perception_msgs::msg::Shape::CYLINDER ) {
     return isInsideCylinder(pose, shape, flow_point);
   } else {
     return false;
@@ -94,17 +95,17 @@ bool ObjectFlowFusion::isInsideShape(
   return true;
 }
 
-geometry_msgs::Twist ObjectFlowFusion::getLocalTwist(
-  const geometry_msgs::Pose& obj_pose, const geometry_msgs::Twist& base_coords_twist)
+geometry_msgs::msg::Twist ObjectFlowFusion::getLocalTwist(
+  const geometry_msgs::msg::Pose& obj_pose, const geometry_msgs::msg::Twist& base_coords_twist)
 {
   Eigen::Affine3d base2obj_transform;
-  tf::poseMsgToEigen(obj_pose, base2obj_transform);
+  poseMsgToEigen(obj_pose, base2obj_transform);
   Eigen::Matrix3d base2obj_rot = base2obj_transform.rotation();
   Eigen::Vector3d obj_coords_vector =
     base2obj_rot.inverse() * Eigen::Vector3d(base_coords_twist.linear.x,
       base_coords_twist.linear.y,
       base_coords_twist.linear.z);
-  geometry_msgs::Twist obj_coords_twist;
+  geometry_msgs::msg::Twist obj_coords_twist;
   obj_coords_twist.linear.x = obj_coords_vector.x();
   obj_coords_twist.linear.y = obj_coords_vector.y();
   obj_coords_twist.linear.z = obj_coords_vector.z();
@@ -113,23 +114,23 @@ geometry_msgs::Twist ObjectFlowFusion::getLocalTwist(
 
 
 bool ObjectFlowFusion::getPolygon(
-  const autoware_perception_msgs::DynamicObject& object,
-  const geometry_msgs::Polygon& input_footprint,
-  geometry_msgs::Polygon& output_footprint)
+  const autoware_perception_msgs::msg::DynamicObject& object,
+  const geometry_msgs::msg::Polygon& input_footprint,
+  geometry_msgs::msg::Polygon& output_footprint)
 {
-  geometry_msgs::Pose pose = object.state.pose_covariance.pose;
-  autoware_perception_msgs::Shape shape = object.shape;
+  geometry_msgs::msg::Pose pose = object.state.pose_covariance.pose;
+  autoware_perception_msgs::msg::Shape shape = object.shape;
 
   Eigen::Affine3d base2obj_transform;
-  tf::poseMsgToEigen(pose, base2obj_transform);
+  poseMsgToEigen(pose, base2obj_transform);
 
   float offset = 0.1;
-  if ( shape.type == autoware_perception_msgs::Shape::BOUNDING_BOX ) {
+  if ( shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX ) {
     auto eigen_c1 = base2obj_transform * Eigen::Vector3d(
       shape.dimensions.x * (0.5 + fusion_box_offset_),
       shape.dimensions.y * (0.5 + fusion_box_offset_),
       0);
-    geometry_msgs::Point32 c1;
+    geometry_msgs::msg::Point32 c1;
     c1.x = eigen_c1.x();
     c1.y = eigen_c1.y();
     output_footprint.points.push_back(c1);
@@ -138,7 +139,7 @@ bool ObjectFlowFusion::getPolygon(
       shape.dimensions.x * (0.5 + fusion_box_offset_),
       -shape.dimensions.y * (0.5 + fusion_box_offset_),
       0);
-    geometry_msgs::Point32 c2;
+    geometry_msgs::msg::Point32 c2;
     c2.x = eigen_c2.x();
     c2.y = eigen_c2.y();
     output_footprint.points.push_back(c2);
@@ -147,7 +148,7 @@ bool ObjectFlowFusion::getPolygon(
       -shape.dimensions.x * (0.5 + fusion_box_offset_),
       -shape.dimensions.y * (0.5 + fusion_box_offset_),
       0);
-    geometry_msgs::Point32 c3;
+    geometry_msgs::msg::Point32 c3;
     c3.x = eigen_c3.x();
     c3.y = eigen_c3.y();
     output_footprint.points.push_back(c3);
@@ -156,20 +157,20 @@ bool ObjectFlowFusion::getPolygon(
       -shape.dimensions.x * (0.5 + fusion_box_offset_),
       shape.dimensions.y * (0.5 + fusion_box_offset_),
       0);
-    geometry_msgs::Point32 c4;
+    geometry_msgs::msg::Point32 c4;
     c4.x = eigen_c4.x();
     c4.y = eigen_c4.y();
     output_footprint.points.push_back(c4);
-  } else if (shape.type == autoware_perception_msgs::Shape::POLYGON) {
+  } else if (shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
     for ( auto p : input_footprint.points ) {
       auto eigen_p = base2obj_transform * Eigen::Vector3d(p.x, p.y, p.z);
-      geometry_msgs::Point32 basecoords_p;
+      geometry_msgs::msg::Point32 basecoords_p;
       basecoords_p.x = eigen_p.x();
       basecoords_p.y = eigen_p.y();
       basecoords_p.z = eigen_p.z();
       output_footprint.points.push_back(basecoords_p);
     }
-  } else if (shape.type == autoware_perception_msgs::Shape::CYLINDER) {
+  } else if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     return true;
   } else {
     return false;
@@ -178,20 +179,20 @@ bool ObjectFlowFusion::getPolygon(
 }
 
 void ObjectFlowFusion::fusion(
-  const autoware_perception_msgs::DynamicObjectWithFeatureArray::ConstPtr& object_msg,
-  const autoware_perception_msgs::DynamicObjectWithFeatureArray::ConstPtr& flow_msg,
+  const autoware_perception_msgs::msg::DynamicObjectWithFeatureArray::ConstPtr& object_msg,
+  const autoware_perception_msgs::msg::DynamicObjectWithFeatureArray::ConstPtr& flow_msg,
   bool use_flow_pose, float flow_vel_thresh_,
-  autoware_perception_msgs::DynamicObjectWithFeatureArray& fusioned_msg)
+  autoware_perception_msgs::msg::DynamicObjectWithFeatureArray& fusioned_msg)
 {
   for (auto detected_object : object_msg->feature_objects) {
-    geometry_msgs::Polygon footprint;
+    geometry_msgs::msg::Polygon footprint;
     bool has_polygon = getPolygon(detected_object.object,
       detected_object.object.shape.footprint,
       footprint);
     if (!has_polygon) {
       continue;
     }
-    geometry_msgs::Twist twist_sum;
+    geometry_msgs::msg::Twist twist_sum;
     size_t flow_count = 0;
     for (auto flow : flow_msg->feature_objects) {
       if ( isInsideShape(detected_object.object,
@@ -204,12 +205,12 @@ void ObjectFlowFusion::fusion(
       }
     }
 
-    autoware_perception_msgs::DynamicObjectWithFeature feature_object;
+    autoware_perception_msgs::msg::DynamicObjectWithFeature feature_object;
     feature_object = detected_object;
     feature_object.object.state.twist_reliable = false;
 
     if ( flow_count > 0 ) {
-      geometry_msgs::Twist twist_average;
+      geometry_msgs::msg::Twist twist_average;
       twist_average.linear.x = twist_sum.linear.x / flow_count;
       twist_average.linear.y = twist_sum.linear.y / flow_count;
       twist_average.linear.z = twist_sum.linear.z / flow_count;
@@ -223,8 +224,8 @@ void ObjectFlowFusion::fusion(
 
         double flow_yaw = std::atan2(mps_twist_average.linear.y, mps_twist_average.linear.x);
         Eigen::Quaterniond eigen_quaternion(Eigen::AngleAxisd(flow_yaw, Eigen::Vector3d::UnitZ()));
-        geometry_msgs::Quaternion q;
-        tf::quaternionEigenToMsg(eigen_quaternion, q);
+        geometry_msgs::msg::Quaternion q;
+        quaternionEigenToMsg(eigen_quaternion, q);
         feature_object.object.state.pose_covariance.pose.orientation = q;
         feature_object.object.state.orientation_reliable = true;
       }
@@ -235,5 +236,29 @@ void ObjectFlowFusion::fusion(
     }
     fusioned_msg.feature_objects.push_back(feature_object);
   }
+}
+
+
+// NOTE(esteve): copied from eigen_conversions
+void ObjectFlowFusion::pointMsgToEigen(const geometry_msgs::msg::Point &m, Eigen::Vector3d &e)
+{
+  e(0) = m.x;
+  e(1) = m.y;
+  e(2) = m.z;
+}
+
+// NOTE(esteve): copied from eigen_conversions
+void ObjectFlowFusion::poseMsgToEigen(const geometry_msgs::msg::Pose &m, Eigen::Affine3d &e)
+{
+  poseMsgToEigenImpl(m, e);
+}
+
+// NOTE(esteve): copied from eigen_conversions
+void ObjectFlowFusion::quaternionEigenToMsg(const Eigen::Quaterniond &e, geometry_msgs::msg::Quaternion &m)
+{
+  m.x = e.x();
+  m.y = e.y();
+  m.z = e.z();
+  m.w = e.w();
 }
 } // object_flow_fusion

--- a/perception/object_recognition/detection/object_flow_fusion/src/utils.cpp
+++ b/perception/object_recognition/detection/object_flow_fusion/src/utils.cpp
@@ -16,44 +16,44 @@
 
 namespace object_flow_fusion
 {
-geometry_msgs::Vector3 Utils::mptopic2kph(
-  const geometry_msgs::Vector3& twist,
+geometry_msgs::msg::Vector3 Utils::mptopic2kph(
+  const geometry_msgs::msg::Vector3& twist,
   double topic_rate)
 {
   // convert twist to [km/h] from [m/topic_rate]
-  geometry_msgs::Vector3 converted_twist;
+  geometry_msgs::msg::Vector3 converted_twist;
   converted_twist.x = (3600.0 / 1000) * twist.x / topic_rate;
   converted_twist.y = (3600.0 / 1000) * twist.y / topic_rate;
   converted_twist.z = (3600.0 / 1000) * twist.z / topic_rate;
   return converted_twist;
 }
 
-geometry_msgs::Vector3 Utils::kph2mptopic(
-  const geometry_msgs::Vector3& twist,
+geometry_msgs::msg::Vector3 Utils::kph2mptopic(
+  const geometry_msgs::msg::Vector3& twist,
   double topic_rate)
 {
   // convert twist to [km/h] from [m/topic_rate]
-  geometry_msgs::Vector3 converted_twist;
+  geometry_msgs::msg::Vector3 converted_twist;
   converted_twist.x = (1000.0 / 3600) * twist.x * topic_rate;
   converted_twist.y = (1000.0 / 3600) * twist.y * topic_rate;
   converted_twist.z = (1000.0 / 3600) * twist.z * topic_rate;
   return converted_twist;
 }
 
-geometry_msgs::Vector3 Utils::kph2mps(const geometry_msgs::Vector3& twist)
+geometry_msgs::msg::Vector3 Utils::kph2mps(const geometry_msgs::msg::Vector3& twist)
 {
   // convert twist to [km/h] from [m/topic_rate]
-  geometry_msgs::Vector3 converted_twist;
+  geometry_msgs::msg::Vector3 converted_twist;
   converted_twist.x = (1000.0 / 3600) * twist.x;
   converted_twist.y = (1000.0 / 3600) * twist.y;
   converted_twist.z = (1000.0 / 3600) * twist.z;
   return converted_twist;
 }
 
-geometry_msgs::Twist Utils::kph2mps(const geometry_msgs::Twist& twist)
+geometry_msgs::msg::Twist Utils::kph2mps(const geometry_msgs::msg::Twist& twist)
 {
   // convert twist to [km/h] from [m/topic_rate]
-  geometry_msgs::Twist converted_twist;
+  geometry_msgs::msg::Twist converted_twist;
   converted_twist.linear.x = (1000.0 / 3600) * twist.linear.x;
   converted_twist.linear.y = (1000.0 / 3600) * twist.linear.y;
   converted_twist.linear.z = (1000.0 / 3600) * twist.linear.z;


### PR DESCRIPTION
This package depends on `eigen_conversions`, which hasn't been ported to ROS 2.

I've filed a ticket upstream about it: https://github.com/ros2/geometry2/issues/350

As a workaround I copied the code from `eigen_conversions` into our codebase. Porting `eigen_conversions` seems straightforward.

Edit: the relevant functions in `eigen_conversions` were added in https://github.com/ros2/geometry2/pull/311, however only in the `ros2` branch, but not in the `foxy` one.