### PR TITLE
Add metapackage for all vehicle descriptions

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -15,3 +15,8 @@ repositories:
     type: git
     url: https://github.com/ApexAI/topic_tools.git
     version: autoware
+  vendor/lexus_description:
+    type: git
+    url: https://github.com/tier4/lexus_description.iv.universe.git
+    version: ros2
+

--- a/vehicle/all_vehicle_descriptions/CMakeLists.txt
+++ b/vehicle/all_vehicle_descriptions/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(all_vehicle_models NONE)
+
+find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_export_dependencies REQUIRED)
+
+ament_package_xml()
+ament_export_dependencies(${${PROJECT_NAME}_EXEC_DEPENDS})
+ament_package()

--- a/vehicle/all_vehicle_descriptions/CMakeLists.txt
+++ b/vehicle/all_vehicle_descriptions/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(all_vehicle_models NONE)
+project(all_vehicle_descriptions NONE)
 
 find_package(ament_cmake_core REQUIRED)
 find_package(ament_cmake_export_dependencies REQUIRED)

--- a/vehicle/all_vehicle_descriptions/package.xml
+++ b/vehicle/all_vehicle_descriptions/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>all_vehicle_descriptions</name>
+  <version>0.0.0</version>
+  <description>A metapackage for all vehicle descriptions. Packages that read in vehicle parameters for a configurable vehicle model should depend on this package to ensure that the parameter files are available at runtime.</description>
+  <maintainer email="nikolai.morin@apex.ai">nikolai.morin</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_core</buildtool_depend>
+  <buildtool_depend>ament_cmake_export_dependencies</buildtool_depend>
+
+  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+
+  <!-- When new vehicle model packages are added, they should be listed here -->
+  <exec_depend>lexus_description</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
The motivation is that the vehicle models used by launch files should be configurable, so the packages with these launch files need a dependency on all possible vehicle models that exist. Currently there is only one vehicle description, but I think Tier IV has more internally and AutowareAuto might add others in the future too.

Instead of adding a list of description packages to each package that uses a vehicle model, which would need to be changed when new models are added, this PR groups the vehicle descriptions into one package that can be used as a dependency that won't change.

This was modeled after the ament_lint_common metapackage.


## Issues
Maybe this would be better placed next to `lexus_description`, but `lexus_description` is its own repository. Maybe it can be renamed to `vehicle_description` and then include `lexus_description` and `all_vehicle_descriptions` as subdirectories.

I am happy to accept suggestions for a better name.