### PR TITLE
Fixed build issues when using fmt::format

### DIFF
--- a/system/autoware_error_monitor/CMakeLists.txt
+++ b/system/autoware_error_monitor/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable(autoware_error_monitor
 )
 
 target_link_libraries(autoware_error_monitor
-  fmt
+  PRIVATE fmt::fmt-header-only
   ${catkin_LIBRARIES}
 )
 

--- a/system/autoware_state_monitor/CMakeLists.txt
+++ b/system/autoware_state_monitor/CMakeLists.txt
@@ -46,7 +46,7 @@ add_executable(autoware_state_monitor
 )
 
 target_link_libraries(autoware_state_monitor
-  fmt
+  PRIVATE fmt::fmt-header-only
   ${catkin_LIBRARIES}
 )
 

--- a/system/util/dummy_diag_publisher/CMakeLists.txt
+++ b/system/util/dummy_diag_publisher/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(dummy_diag_publisher
 )
 
 target_link_libraries(dummy_diag_publisher
-  fmt
+  PRIVATE fmt::fmt-header-only
   ${catkin_LIBRARIES}
 )
 


### PR DESCRIPTION
## PRの種類

- [ ] 新機能
- [ ] 既存機能の性能向上
- [x ] バグフィックス

## Jiraリンク

## 変更概要
When trying to build Pilot.auto with `AUTOWARE_COMPILE_WITH_CUDA=1 colcon build  --cmake-args -DCMAKE_BUILD_TYPE=Release`, build process always failed on `autoware_state_monitor`, `autoware_error_monitor` and `dummy_diag_publisher`. Even if `libfmt-dev` is installed, linker complained of several errors, see the following screenshot:

![image](https://user-images.githubusercontent.com/16696954/102042666-c11bec00-3e15-11eb-814b-00ef3dc64e92.png)

Installing from source the fmt library did not help. The solution was not use the static library `libfmt.a` but use the pre-compiled headers (which seems to be the recommended approach); this was done by replacing the 'fmt' by 'PRIVATE fmt::fmt-header-only' in `target_link_libraries` line in CMakeLists.txt respective files, as shown below:

![image](https://user-images.githubusercontent.com/16696954/102042764-07714b00-3e16-11eb-951e-ad4058d76303.png)

Replacing this line in the CMakeLists.txt files for `autoware_state_monitor`, `autoware_error_monitor` and `dummy_diag_publisher` solved the building problem.

## レビュー方法
Just apply the changes and build one of the above packages:
`AUTOWARE_COMPILE_WITH_CUDA=1 colcon build --packages-select=dummy_diag_publisher --cmake-args -DCMAKE_BUILD_TYPE=Release`

## その他

- [ ] [リリースノート](https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416)への記載
