### PR TITLE
Modify autoware state monitor

### DIFF
--- a/system/autoware_state_monitor/config/autoware_state_monitor.planning_simulation.yaml
+++ b/system/autoware_state_monitor/config/autoware_state_monitor.planning_simulation.yaml
@@ -107,11 +107,11 @@
     ## configs: top level
     ### names used to declare parameter group
     #### module: string
-    param_configs:
-      names: ["/vehicle_info"]
-      configs:
-        /vehicle_info:
-          module: "vehicle"
+    # param_configs:
+    #   names: ["/vehicle_info"]
+    #   configs:
+    #     /vehicle_info:
+    #       module: "vehicle"
 
     # TF Config
     ## names: string array

--- a/system/autoware_state_monitor/config/autoware_state_monitor.yaml
+++ b/system/autoware_state_monitor/config/autoware_state_monitor.yaml
@@ -134,11 +134,11 @@
     ## configs: top level
     ### names used to declare parameter group
     #### module: string
-    param_configs:
-      names: ["/vehicle_info"]
-      configs:
-        /vehicle_info:
-          module: "vehicle"
+    # param_configs:
+    #   names: ["/vehicle_info"]
+    #   configs:
+    #     /vehicle_info:
+    #       module: "vehicle"
 
     # TF Config
     ## names: string array


### PR DESCRIPTION
## What kinds of PR

- [ ] New fearue
- [ ] Improve feature
- [x] Buf fix

## What is this PR
Fix minor issues in `autoware_state_monitor`
1. Disable /vehicle_info param check since we don't have global /vehicle_info in ROS2 implementation.
2. Fix rate to 10hz as intended.
3. Fix uninitialized currrent_time.
4. Fix to subscribe latched route msg



