### PR TITLE
Fix dt in pose2twist

### DIFF
--- a/localization/twist_estimator/pose2twist/src/pose2twist_core.cpp
+++ b/localization/twist_estimator/pose2twist/src/pose2twist_core.cpp
@@ -70,7 +70,8 @@ geometry_msgs::msg::TwistStamped calcTwist(
   geometry_msgs::msg::PoseStamped::SharedPtr pose_a,
   geometry_msgs::msg::PoseStamped::SharedPtr pose_b)
 {
-  const double dt = (pose_b->header.stamp.sec - pose_a->header.stamp.sec);
+  const double dt =
+        (rclcpp::Time(pose_b->header.stamp) - rclcpp::Time(pose_a->header.stamp)).seconds();
 
   if (dt == 0) {
     geometry_msgs::msg::TwistStamped twist;

--- a/localization/twist_estimator/pose2twist/src/pose2twist_core.cpp
+++ b/localization/twist_estimator/pose2twist/src/pose2twist_core.cpp
@@ -20,8 +20,7 @@
 
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
-Pose2Twist::Pose2Twist()
-: Node("pose2twist_core")
+Pose2Twist::Pose2Twist() : Node("pose2twist_core")
 {
   using std::placeholders::_1;
 
@@ -29,11 +28,8 @@ Pose2Twist::Pose2Twist()
   rclcpp::QoS durable_qos(queue_size);
   durable_qos.transient_local();
 
-  pose_sub_ =
-    create_subscription<geometry_msgs::msg::PoseStamped>(
-    "pose", queue_size,
-    std::bind(&Pose2Twist::callbackPose, this, _1));
-
+  pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
+    "pose", queue_size, std::bind(&Pose2Twist::callbackPose, this, _1));
 
   twist_pub_ = create_publisher<geometry_msgs::msg::TwistStamped>("twist", durable_qos);
   linear_x_pub_ = create_publisher<std_msgs::msg::Float32>("linear_x", durable_qos);
@@ -55,8 +51,8 @@ double calcDiffForRadian(const double lhs_rad, const double rhs_rad)
 geometry_msgs::msg::Vector3 getRPY(geometry_msgs::msg::Pose::SharedPtr pose)
 {
   geometry_msgs::msg::Vector3 rpy;
-  tf2::Quaternion q(pose->orientation.x, pose->orientation.y, pose->orientation.z,
-    pose->orientation.w);
+  tf2::Quaternion q(
+    pose->orientation.x, pose->orientation.y, pose->orientation.z, pose->orientation.w);
   tf2::Matrix3x3(q).getRPY(rpy.x, rpy.y, rpy.z);
   return rpy;
 }
@@ -71,7 +67,7 @@ geometry_msgs::msg::TwistStamped calcTwist(
   geometry_msgs::msg::PoseStamped::SharedPtr pose_b)
 {
   const double dt =
-        (rclcpp::Time(pose_b->header.stamp) - rclcpp::Time(pose_a->header.stamp)).seconds();
+    (rclcpp::Time(pose_b->header.stamp) - rclcpp::Time(pose_a->header.stamp)).seconds();
 
   if (dt == 0) {
     geometry_msgs::msg::TwistStamped twist;


### PR DESCRIPTION
## What kinds of PR

- [ ] New feature
- [ ] Improve feature
- [x] Bug Fix

## What is this PR
Fix to calculate accurate dt in `double` data type. Current implementation calculate dt in `int` data type.
ref: https://github.com/tier4/AutowareArchitectureProposal.iv/blob/ros2/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp#L124