### PR TITLE
[gnss_poser] fix link to Geographiclib

### DIFF
--- a/sensing/preprocessor/gnss/gnss_poser/CMakeLists.txt
+++ b/sensing/preprocessor/gnss/gnss_poser/CMakeLists.txt
@@ -15,7 +15,8 @@ endif()
 find_package(PkgConfig)
 find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
   PATH_SUFFIXES GeographicLib
-  )
+)
+
 set(GeographicLib_INCLUDE_DIRS ${GeographicLib_INCLUDE_DIR})
 find_library(GeographicLib_LIBRARIES
   NAMES Geographic

--- a/sensing/preprocessor/gnss/gnss_poser/CMakeLists.txt
+++ b/sensing/preprocessor/gnss/gnss_poser/CMakeLists.txt
@@ -11,6 +11,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
 endif()
 
+## Find non-ROS library
+find_package(PkgConfig)
+find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
+  PATH_SUFFIXES GeographicLib
+  )
+set(GeographicLib_INCLUDE_DIRS ${GeographicLib_INCLUDE_DIR})
+find_library(GeographicLib_LIBRARIES
+  NAMES Geographic
+)
+
 find_package(ament_cmake_auto)
 ament_auto_find_build_dependencies()
 
@@ -23,6 +33,10 @@ set(GNSS_POSER_HEADERS
 ament_auto_add_library(gnss_poser_node SHARED
   src/gnss_poser_core.cpp
   ${GNSS_POSER_HEADERS}
+)
+
+target_link_libraries(gnss_poser_node
+  Geographic
 )
 
 rclcpp_components_register_node(gnss_poser_node


### PR DESCRIPTION
This fixes missing link to Geographic lib package.
It has been tested with an actual sensor data.