### PR TITLE
Ros2 v0.8.0 engage

### DIFF
--- a/awapi/awapi_awiv_adapter/Readme.md
+++ b/awapi/awapi_awiv_adapter/Readme.md
@@ -183,11 +183,11 @@
 ### /awapi/autoware/put/engage
 
 - send engage signal (both of autoware/engage and vehicle/engage)
-- MessageType: autoware_control_msgs/EngageMode
+- MessageType: autoware_vehicle_msgs/Engage
 
 | ✓   | type                             | name | unit | note |
 | --- | :------------------------------- | :--- | :--- | :--- |
-| ✓   | autoware_control_msgs/EngageMode |      |      |      |
+| ✓   | autoware_vehicle_msgs/Engage |      |      |      |
 
 ### /awapi/autoware/put/goal
 

--- a/awapi/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
+++ b/awapi/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
@@ -154,12 +154,12 @@
     <node pkg="topic_tools" exec="relay" name="autoware_engage_relay" output="log" >
       <param name="input_topic" value="$(var set_engage)" />
       <param name="output_topic" value="$(var output_autoware_engage)" />
-      <param name="type" value="autoware_control_msgs/msg/EngageMode" />
+      <param name="type" value="autoware_vehicle_msgs/msg/Engage" />
     </node>
     <node pkg="topic_tools" exec="relay" name="vehicle_engage_relay" output="log" >
       <param name="input_topic" value="$(var set_engage)" />
       <param name="output_topic" value="$(var output_vehicle_engage)" />
-      <param name="type" value="autoware_control_msgs/msg/EngageMode" />
+      <param name="type" value="autoware_vehicle_msgs/msg/Engage" />
     </node>
     <node pkg="topic_tools" exec="relay" name="put_route_relay" output="log" >
       <param name="input_topic" value="$(var set_route)" />

--- a/common/msgs/autoware_control_msgs/CMakeLists.txt
+++ b/common/msgs/autoware_control_msgs/CMakeLists.txt
@@ -15,7 +15,6 @@ find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/EmergencyMode.msg"
-  "msg/EngageMode.msg"
   "msg/GateMode.msg"
   "msg/ControlCommand.msg"
   "msg/ControlCommandStamped.msg"

--- a/common/msgs/autoware_control_msgs/msg/EngageMode.msg
+++ b/common/msgs/autoware_control_msgs/msg/EngageMode.msg
@@ -1,1 +1,0 @@
-bool is_engaged

--- a/common/msgs/autoware_vehicle_msgs/CMakeLists.txt
+++ b/common/msgs/autoware_vehicle_msgs/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(autoware_control_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/Engage.msg"
   "msg/VehicleCommand.msg"
   "msg/Shift.msg"
   "msg/ShiftStamped.msg"

--- a/common/msgs/autoware_vehicle_msgs/msg/Engage.msg
+++ b/common/msgs/autoware_vehicle_msgs/msg/Engage.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+bool engage

--- a/common/util/web_controller/autoware_web_controller/www/autoware_web_controller/js/autoware_engage.js
+++ b/common/util/web_controller/autoware_web_controller/www/autoware_web_controller/js/autoware_engage.js
@@ -19,7 +19,7 @@ if (!AutowareEngagePublisher) {
             var pub = new ROSLIB.Topic({
                 ros: this.ros,
                 name: '/autoware/engage',
-                messageType: 'autoware_control_msgs/EngageMode',
+                messageType: 'autoware_vehicle_msgs/Engage',
                 latch: 'true'
             });
 
@@ -63,7 +63,7 @@ if (!AutowareEngageStatusSubscriber) {
             var sub = new ROSLIB.Topic({
                 ros: this.ros,
                 name: '/autoware/engage',
-                messageType: 'autoware_control_msgs/EngageMode'
+                messageType: 'autoware_vehicle_msgs/Engage'
             });
             sub.subscribe(function(message) {
                 const div = document.getElementById("autoware_engage_status");

--- a/control/vehicle_cmd_gate/include/vehicle_cmd_gate/vehicle_cmd_gate.hpp
+++ b/control/vehicle_cmd_gate/include/vehicle_cmd_gate/vehicle_cmd_gate.hpp
@@ -22,8 +22,8 @@
 
 #include "autoware_control_msgs/msg/control_command_stamped.hpp"
 #include "autoware_control_msgs/msg/emergency_mode.hpp"
-#include "autoware_control_msgs/msg/engage_mode.hpp"
 #include "autoware_control_msgs/msg/gate_mode.hpp"
+#include "autoware_vehicle_msgs/msg/engage.hpp"
 #include "autoware_vehicle_msgs/msg/shift_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/steering.hpp"
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
@@ -53,17 +53,17 @@ private:
   rclcpp::Publisher<autoware_control_msgs::msg::GateMode>::SharedPtr gate_mode_pub_;
 
   // Subscription
-  rclcpp::Subscription<autoware_control_msgs::msg::EngageMode>::SharedPtr engage_sub_;
   rclcpp::Subscription<autoware_control_msgs::msg::EmergencyMode>::SharedPtr system_emergency_sub_;
   rclcpp::Subscription<autoware_control_msgs::msg::EmergencyMode>::SharedPtr
     external_emergency_stop_sub_;
   rclcpp::Subscription<autoware_control_msgs::msg::GateMode>::SharedPtr gate_mode_sub_;
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::Engage>::SharedPtr engage_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::Steering>::SharedPtr steer_sub_;
 
   void onGateMode(autoware_control_msgs::msg::GateMode::ConstSharedPtr msg);
-  void onEngage(autoware_control_msgs::msg::EngageMode::ConstSharedPtr msg);
   void onSystemEmergency(autoware_control_msgs::msg::EmergencyMode::ConstSharedPtr msg);
   void onExternalEmergencyStop(autoware_control_msgs::msg::EmergencyMode::ConstSharedPtr msg);
+  void onEngage(autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
   void onSteering(autoware_vehicle_msgs::msg::Steering::ConstSharedPtr msg);
 
   bool is_engaged_;

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -79,8 +79,6 @@ VehicleCmdGate::VehicleCmdGate()
     this->create_publisher<autoware_control_msgs::msg::GateMode>("output/gate_mode", durable_qos);
 
   // Subscriber
-  engage_sub_ = this->create_subscription<autoware_control_msgs::msg::EngageMode>(
-    "input/engage", 1, std::bind(&VehicleCmdGate::onEngage, this, _1));
   system_emergency_sub_ = this->create_subscription<autoware_control_msgs::msg::EmergencyMode>(
     "input/system_emergency", 1, std::bind(&VehicleCmdGate::onSystemEmergency, this, _1));
   external_emergency_stop_sub_ =
@@ -89,6 +87,8 @@ VehicleCmdGate::VehicleCmdGate()
       std::bind(&VehicleCmdGate::onExternalEmergencyStop, this, _1));
   gate_mode_sub_ = this->create_subscription<autoware_control_msgs::msg::GateMode>(
     "input/gate_mode", 1, std::bind(&VehicleCmdGate::onGateMode, this, _1));
+  engage_sub_ = this->create_subscription<autoware_vehicle_msgs::msg::Engage>(
+    "input/engage", 1, std::bind(&VehicleCmdGate::onEngage, this, _1));
   steer_sub_ = this->create_subscription<autoware_vehicle_msgs::msg::Steering>(
     "input/steering", 1, std::bind(&VehicleCmdGate::onSteering, this, _1));
 
@@ -462,11 +462,6 @@ autoware_control_msgs::msg::ControlCommand VehicleCmdGate::createEmergencyStopCo
   return cmd;
 }
 
-void VehicleCmdGate::onEngage(autoware_control_msgs::msg::EngageMode::ConstSharedPtr msg)
-{
-  is_engaged_ = msg->is_engaged;
-}
-
 void VehicleCmdGate::onSystemEmergency(
   autoware_control_msgs::msg::EmergencyMode::ConstSharedPtr msg)
 {
@@ -493,6 +488,11 @@ void VehicleCmdGate::onGateMode(autoware_control_msgs::msg::GateMode::ConstShare
       get_logger(), "GateMode changed: %s -> %s", getGateModeName(prev_gate_mode.data),
       getGateModeName(current_gate_mode_.data));
   }
+}
+
+void VehicleCmdGate::onEngage(autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
+{
+  is_engaged_ = msg->engage;
 }
 
 void VehicleCmdGate::onSteering(autoware_vehicle_msgs::msg::Steering::ConstSharedPtr msg)

--- a/simulator/simple_planning_simulator/CMakeLists.txt
+++ b/simulator/simple_planning_simulator/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(autoware_debug_msgs REQUIRED)
 find_package(autoware_planning_msgs REQUIRED)
 find_package(autoware_control_msgs REQUIRED)
 find_package(autoware_vehicle_msgs REQUIRED)
@@ -42,6 +43,7 @@ set(SIMPLE_PLANNING_SIMULATOR_DEPENDENCIES
   geometry_msgs
   tf2
   tf2_ros
+  autoware_debug_msgs
   autoware_planning_msgs
   autoware_control_msgs
   autoware_vehicle_msgs

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -27,10 +27,6 @@
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "std_msgs/msg/bool.hpp"
-#include "std_msgs/msg/float32.hpp"
-#include "std_msgs/msg/int32.hpp"
-#include "std_msgs/msg/string.hpp"
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2/utils.h"
 #include "tf2_ros/transform_broadcaster.h"
@@ -39,8 +35,10 @@
 #include "eigen3/Eigen/LU"
 #include <random>
 
+#include "autoware_debug_msgs/msg/float32_stamped.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "autoware_vehicle_msgs/msg/control_mode.hpp"
+#include "autoware_vehicle_msgs/msg/engage.hpp"
 #include "autoware_vehicle_msgs/msg/shift_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/steering.hpp"
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
@@ -69,7 +67,7 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_pose_;   //!< @brief topic ros publisher for current pose
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr pub_twist_;  //!< @brief topic ros publisher for current twist
   rclcpp::Publisher<autoware_vehicle_msgs::msg::Steering>::SharedPtr pub_steer_;
-  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_velocity_;
+  rclcpp::Publisher<autoware_debug_msgs::msg::Float32Stamped>::SharedPtr pub_velocity_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr pub_turn_signal_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::ShiftStamped>::SharedPtr pub_shift_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::ControlMode>::SharedPtr pub_control_mode_;
@@ -79,7 +77,7 @@ private:
   rclcpp::Subscription<autoware_planning_msgs::msg::Trajectory>::SharedPtr sub_trajectory_;   //!< @brief topic subscriber for trajectory used for z ppsition
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr sub_initialpose_;  //!< @brief topic subscriber for initialpose topic
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_initialtwist_;  //!< @brief topic subscriber for initialtwist topic
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_engage_;        //!< @brief topic subscriber for engage topic
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::Engage>::SharedPtr sub_engage_;        //!< @brief topic subscriber for engage topic
   rclcpp::TimerBase::SharedPtr timer_simulation_;       //!< @brief timer for simulation
 
   /* tf */
@@ -183,7 +181,7 @@ private:
   /**
    * @brief set simulator engage with received message
    */
-  void callbackEngage(const std_msgs::msg::Bool::ConstSharedPtr msg);
+  void callbackEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
 
   /**
    * @brief get transform from two frame_ids

--- a/simulator/simple_planning_simulator/package.xml
+++ b/simulator/simple_planning_simulator/package.xml
@@ -15,6 +15,7 @@
   <depend>geometry_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>autoware_debug_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator_core.cpp
@@ -36,8 +36,8 @@ Simulator::Simulator(const std::string & node_name, const rclcpp::NodeOptions & 
     "output/control_mode", rclcpp::QoS{1});
   pub_steer_ = create_publisher<autoware_vehicle_msgs::msg::Steering>(
     "/vehicle/status/steering", rclcpp::QoS{1});
-  pub_velocity_ =
-    create_publisher<std_msgs::msg::Float32>("/vehicle/status/velocity", rclcpp::QoS{1});
+  pub_velocity_ = create_publisher<autoware_debug_msgs::msg::Float32Stamped>(
+    "/vehicle/status/velocity", rclcpp::QoS{1});
   pub_turn_signal_ = create_publisher<autoware_vehicle_msgs::msg::TurnSignal>(
     "/vehicle/status/turn_signal", rclcpp::QoS{1});
   pub_shift_ = create_publisher<autoware_vehicle_msgs::msg::ShiftStamped>(
@@ -56,7 +56,7 @@ Simulator::Simulator(const std::string & node_name, const rclcpp::NodeOptions & 
     "input/initial_twist", rclcpp::QoS{1},
     std::bind(&Simulator::callbackInitialTwistStamped, this, std::placeholders::_1));
 
-  sub_engage_ = create_subscription<std_msgs::msg::Bool>(
+  sub_engage_ = create_subscription<autoware_vehicle_msgs::msg::Engage>(
     "input/engage", rclcpp::QoS{1},
     std::bind(&Simulator::callbackEngage, this, std::placeholders::_1));
   sub_initialpose_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
@@ -199,9 +199,9 @@ void Simulator::callbackInitialTwistStamped(
   }
 }
 
-void Simulator::callbackEngage(const std_msgs::msg::Bool::ConstSharedPtr msg)
+void Simulator::callbackEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
 {
-  simulator_engage_ = msg->data;
+  simulator_engage_ = msg->engage;
 }
 
 void Simulator::timerCallbackSimulation()
@@ -276,7 +276,8 @@ void Simulator::timerCallbackSimulation()
   pub_steer_->publish(steer_msg);
 
   /* float info publishers */
-  std_msgs::msg::Float32 velocity_msg;
+  autoware_debug_msgs::msg::Float32Stamped velocity_msg;
+  velocity_msg.stamp = this->now();
   velocity_msg.data = current_twist_.linear.x;
   pub_velocity_->publish(velocity_msg);
 

--- a/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state_monitor_node.hpp
+++ b/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state_monitor_node.hpp
@@ -28,9 +28,9 @@
 #include "autoware_planning_msgs/msg/route.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "autoware_control_msgs/msg/emergency_mode.hpp"
-#include "autoware_control_msgs/msg/engage_mode.hpp"
 #include "autoware_system_msgs/msg/autoware_state.hpp"
 #include "autoware_vehicle_msgs/msg/control_mode.hpp"
+#include "autoware_vehicle_msgs/msg/engage.hpp"
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
@@ -63,14 +63,14 @@ private:
   geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose_;
 
   // Subscriber
-  rclcpp::Subscription<autoware_control_msgs::msg::EngageMode>::SharedPtr sub_autoware_engage_;
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::Engage>::SharedPtr sub_autoware_engage_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::ControlMode>::SharedPtr
     sub_vehicle_control_mode_;
   rclcpp::Subscription<autoware_control_msgs::msg::EmergencyMode>::SharedPtr sub_is_emergency_;
   rclcpp::Subscription<autoware_planning_msgs::msg::Route>::SharedPtr sub_route_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_twist_;
 
-  void onAutowareEngage(const autoware_control_msgs::msg::EngageMode::ConstSharedPtr msg);
+  void onAutowareEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
   void onVehicleControlMode(const autoware_vehicle_msgs::msg::ControlMode::ConstSharedPtr msg);
   void onIsEmergency(const autoware_control_msgs::msg::EmergencyMode::ConstSharedPtr msg);
   void onRoute(const autoware_planning_msgs::msg::Route::ConstSharedPtr msg);
@@ -95,7 +95,7 @@ private:
 
   // Publisher
   rclcpp::Publisher<autoware_system_msgs::msg::AutowareState>::SharedPtr pub_autoware_state_;
-  rclcpp::Publisher<autoware_control_msgs::msg::EngageMode>::SharedPtr pub_autoware_engage_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::Engage>::SharedPtr pub_autoware_engage_;
 
   bool isEngaged();
   void setDisengage();

--- a/system/autoware_state_monitor/include/autoware_state_monitor/state_machine.hpp
+++ b/system/autoware_state_monitor/include/autoware_state_monitor/state_machine.hpp
@@ -22,9 +22,9 @@
 #include "autoware_planning_msgs/msg/route.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "autoware_control_msgs/msg/emergency_mode.hpp"
-#include "autoware_control_msgs/msg/engage_mode.hpp"
 #include "autoware_system_msgs/msg/autoware_state.hpp"
 #include "autoware_vehicle_msgs/msg/control_mode.hpp"
+#include "autoware_vehicle_msgs/msg/engage.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "rclcpp/time.hpp"
@@ -44,7 +44,7 @@ struct StateInput
   geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose;
   geometry_msgs::msg::Pose::ConstSharedPtr goal_pose;
 
-  autoware_control_msgs::msg::EngageMode::ConstSharedPtr autoware_engage;
+  autoware_vehicle_msgs::msg::Engage::ConstSharedPtr autoware_engage;
   autoware_vehicle_msgs::msg::ControlMode::ConstSharedPtr vehicle_control_mode;
   autoware_control_msgs::msg::EmergencyMode::ConstSharedPtr emergency_mode;
   bool is_finalizing = false;

--- a/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
+++ b/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
@@ -117,7 +117,7 @@ std::string getStateMessage(const AutowareState & state)
 }  // namespace
 
 void AutowareStateMonitorNode::onAutowareEngage(
-  const autoware_control_msgs::msg::EngageMode::ConstSharedPtr msg)
+  const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
 {
   state_input_.autoware_engage = msg;
 }
@@ -376,13 +376,14 @@ bool AutowareStateMonitorNode::isEngaged()
     return false;
   }
 
-  return state_input_.autoware_engage->is_engaged;
+  return state_input_.autoware_engage->engage;
 }
 
 void AutowareStateMonitorNode::setDisengage()
 {
-  autoware_control_msgs::msg::EngageMode msg;
-  msg.is_engaged = false;
+  autoware_vehicle_msgs::msg::Engage msg;
+  msg.stamp = this->now();
+  msg.engage = false;
   pub_autoware_engage_->publish(msg);
 }
 
@@ -422,7 +423,7 @@ AutowareStateMonitorNode::AutowareStateMonitorNode()
   }
 
   // Subscriber
-  sub_autoware_engage_ = this->create_subscription<autoware_control_msgs::msg::EngageMode>(
+  sub_autoware_engage_ = this->create_subscription<autoware_vehicle_msgs::msg::Engage>(
     "input/autoware_engage", 1,
     std::bind(&AutowareStateMonitorNode::onAutowareEngage, this, _1));
   sub_vehicle_control_mode_ = this->create_subscription<autoware_vehicle_msgs::msg::ControlMode>(
@@ -445,7 +446,7 @@ AutowareStateMonitorNode::AutowareStateMonitorNode()
   pub_autoware_state_ =
     this->create_publisher<autoware_system_msgs::msg::AutowareState>("output/autoware_state", 1);
   pub_autoware_engage_ =
-    this->create_publisher<autoware_control_msgs::msg::EngageMode>("output/autoware_engage", 1);
+    this->create_publisher<autoware_vehicle_msgs::msg::Engage>("output/autoware_engage", 1);
 
   // Diagnostic Updater
   setupDiagnosticUpdater();

--- a/system/autoware_state_monitor/src/autoware_state_monitor_node/state_machine.cpp
+++ b/system/autoware_state_monitor/src/autoware_state_monitor_node/state_machine.cpp
@@ -154,7 +154,7 @@ bool StateMachine::isEngaged() const
     return false;
   }
 
-  if (state_input_.autoware_engage->is_engaged != 1) {
+  if (state_input_.autoware_engage->engage != 1) {
     return false;
   }
 

--- a/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
+++ b/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
@@ -27,7 +27,6 @@
 
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/bool.hpp"
 
 #include "pacmod_msgs/msg/global_rpt.hpp"
 #include "pacmod_msgs/msg/steer_system_cmd.hpp"
@@ -38,6 +37,7 @@
 #include "pacmod_msgs/msg/wheel_speed_rpt.hpp"
 
 #include "autoware_vehicle_msgs/msg/control_mode.hpp"
+#include "autoware_vehicle_msgs/msg/engage.hpp"
 #include "autoware_vehicle_msgs/msg/raw_vehicle_command.hpp"
 #include "autoware_vehicle_msgs/msg/shift_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/steering.hpp"
@@ -62,7 +62,7 @@ private:
   rclcpp::Subscription<autoware_vehicle_msgs::msg::RawVehicleCommand>::SharedPtr
     raw_vehicle_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr turn_signal_cmd_sub_;
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr engage_cmd_sub_;
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::Engage>::SharedPtr engage_cmd_sub_;
 
   // From Pacmod
   std::unique_ptr<message_filters::Subscriber<pacmod_msgs::msg::SystemRptFloat>>
@@ -151,7 +151,7 @@ private:
   /* callbacks */
   void callbackVehicleCmd(const autoware_vehicle_msgs::msg::RawVehicleCommand::ConstSharedPtr msg);
   void callbackTurnSignalCmd(const autoware_vehicle_msgs::msg::TurnSignal::ConstSharedPtr msg);
-  void callbackEngage(const std_msgs::msg::Bool::ConstSharedPtr msg);
+  void callbackEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
   void callbackPacmodRpt(
     const pacmod_msgs::msg::SystemRptFloat::ConstSharedPtr steer_wheel_rpt,
     const pacmod_msgs::msg::WheelSpeedRpt::ConstSharedPtr wheel_speed_rpt,

--- a/vehicle/as/include/ssc_interface/ssc_interface.hpp
+++ b/vehicle/as/include/ssc_interface/ssc_interface.hpp
@@ -26,8 +26,6 @@
 
 #include "builtin_interfaces/msg/time.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "std_msgs/msg/bool.hpp"
-#include "std_msgs/msg/float32.hpp"
 #include "std_msgs/msg/header.hpp"
 
 #include "automotive_navigation_msgs/msg/module_state.hpp"
@@ -44,7 +42,9 @@
 #include "pacmod_msgs/msg/system_rpt_int.hpp"
 #include "pacmod_msgs/msg/wheel_speed_rpt.hpp"
 
+#include "autoware_debug_msgs/msg/float32_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/control_mode.hpp"
+#include "autoware_vehicle_msgs/msg/engage.hpp"
 #include "autoware_vehicle_msgs/msg/shift_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/steering.hpp"
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
@@ -70,7 +70,7 @@ private:
   // subscribers
   rclcpp::Subscription<autoware_vehicle_msgs::msg::VehicleCommand>::SharedPtr vehicle_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr turn_signal_cmd_sub_;
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr engage_sub_;
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::Engage>::SharedPtr engage_sub_;
   rclcpp::Subscription<automotive_navigation_msgs::msg::ModuleState>::SharedPtr module_states_sub_;
 
   std::unique_ptr<message_filters::Subscriber<automotive_platform_msgs::msg::VelocityAccelCov>>
@@ -100,9 +100,10 @@ private:
   rclcpp::Publisher<autoware_vehicle_msgs::msg::ControlMode>::SharedPtr control_mode_pub_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr current_twist_pub_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::Steering>::SharedPtr current_steer_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr current_steer_wheel_deg_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr current_velocity_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr current_velocity_kmph_pub_;
+  rclcpp::Publisher<autoware_debug_msgs::msg::Float32Stamped>::SharedPtr
+    current_steer_wheel_deg_pub_;
+  rclcpp::Publisher<autoware_debug_msgs::msg::Float32Stamped>::SharedPtr current_velocity_pub_;
+  rclcpp::Publisher<autoware_debug_msgs::msg::Float32Stamped>::SharedPtr current_velocity_kmph_pub_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr current_turn_signal_pub_;
 
   rclcpp::TimerBase::SharedPtr timer_;
@@ -147,7 +148,7 @@ private:
   // callbacks
   void callbackFromVehicleCmd(const autoware_vehicle_msgs::msg::VehicleCommand::ConstSharedPtr msg);
   void callbackFromTurnSignalCmd(const autoware_vehicle_msgs::msg::TurnSignal::ConstSharedPtr msg);
-  void callbackFromEngage(const std_msgs::msg::Bool::ConstSharedPtr msg);
+  void callbackFromEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
   void callbackFromSSCModuleStates(
     const automotive_navigation_msgs::msg::ModuleState::ConstSharedPtr msg);
   void callbackFromSSCFeedbacks(

--- a/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
@@ -72,7 +72,7 @@ PacmodInterface::PacmodInterface()
   turn_signal_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::TurnSignal>(
     "/control/turn_signal_cmd", rclcpp::QoS{1},
     std::bind(&PacmodInterface::callbackTurnSignalCmd, this, _1));
-  engage_cmd_sub_ = create_subscription<std_msgs::msg::Bool>(
+  engage_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::Engage>(
     "/vehicle/engage", rclcpp::QoS{1}, std::bind(&PacmodInterface::callbackEngage, this, _1));
 
   // From pacmod
@@ -153,9 +153,9 @@ void PacmodInterface::callbackTurnSignalCmd(
 {
   turn_signal_cmd_ptr_ = msg;
 }
-void PacmodInterface::callbackEngage(const std_msgs::msg::Bool::ConstSharedPtr msg)
+void PacmodInterface::callbackEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
 {
-  engage_cmd_ = msg->data;
+  engage_cmd_ = msg->engage;
   is_clear_override_needed_ = true;
 }
 

--- a/vehicle/as/src/ssc_interface/ssc_interface.cpp
+++ b/vehicle/as/src/ssc_interface/ssc_interface.cpp
@@ -46,7 +46,7 @@ SSCInterface::SSCInterface()
   turn_signal_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::TurnSignal>(
     "/control/turn_signal_cmd", rclcpp::QoS{1},
     std::bind(&SSCInterface::callbackFromTurnSignalCmd, this, _1));
-  engage_sub_ = create_subscription<std_msgs::msg::Bool>(
+  engage_sub_ = create_subscription<autoware_vehicle_msgs::msg::Engage>(
     "/vehcle/engage", rclcpp::QoS{1},
     std::bind(&SSCInterface::callbackFromEngage, this, _1));
 
@@ -101,12 +101,12 @@ SSCInterface::SSCInterface()
     create_publisher<geometry_msgs::msg::TwistStamped>("/vehicle/status/twist", rclcpp::QoS{10});
   current_steer_pub_ = create_publisher<autoware_vehicle_msgs::msg::Steering>(
     "/vehicle/status/steering", rclcpp::QoS{10});
-  current_steer_wheel_deg_pub_ =
-    create_publisher<std_msgs::msg::Float32>("/vehicle/status/steering_wheel_deg", rclcpp::QoS{10});
-  current_velocity_pub_ =
-    create_publisher<std_msgs::msg::Float32>("/vehicle/status/velocity", rclcpp::QoS{10});
-  current_velocity_kmph_pub_ =
-    create_publisher<std_msgs::msg::Float32>("/vehicle/status/velocity_kmph", rclcpp::QoS{10});
+  current_steer_wheel_deg_pub_ = create_publisher<autoware_debug_msgs::msg::Float32Stamped>(
+    "/vehicle/status/steering_wheel_deg", rclcpp::QoS{10});
+  current_velocity_pub_ = create_publisher<autoware_debug_msgs::msg::Float32Stamped>(
+    "/vehicle/status/velocity", rclcpp::QoS{10});
+  current_velocity_kmph_pub_ = create_publisher<autoware_debug_msgs::msg::Float32Stamped>(
+    "/vehicle/status/velocity_kmph", rclcpp::QoS{10});
   current_turn_signal_pub_ = create_publisher<autoware_vehicle_msgs::msg::TurnSignal>(
     "/vehicle/status/turn_signal", rclcpp::QoS{10});
 
@@ -147,9 +147,9 @@ void SSCInterface::callbackFromTurnSignalCmd(
   turn_signal_cmd_ = *msg;
   turn_signal_cmd_initialized_ = true;
 }
-void SSCInterface::callbackFromEngage(const std_msgs::msg::Bool::ConstSharedPtr msg)
+void SSCInterface::callbackFromEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
 {
-  engage_ = msg->data;
+  engage_ = msg->engage;
 }
 
 void SSCInterface::callbackFromSSCModuleStates(


### PR DESCRIPTION
* Use autoware_vehicle_msgs/msg/Engage instead of autoware_control_msgs/msg/EngageMode.
* Remove std_msgs from as.