### PR TITLE
fix boost_none handling

### DIFF
--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -1251,7 +1251,7 @@ boost::optional<double> MPTOptimizer::getValidLatError(
       return boost::none;
     }
     if (!enable_avoidance) {
-      *obj_clearance = std::numeric_limits<double>::max();
+      obj_clearance.emplace(std::numeric_limits<double>::max());
     }
     if (search_expanding_side) {
       if (clearance.get() > min_road_clearance && obj_clearance.get() > min_obj_clearance) {

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -1205,8 +1205,8 @@ double MPTOptimizer::getTraversedDistance(
     auto clearance = getClearance(maps.clearance_map, new_position, maps.map_info);
     auto obj_clearance = getClearance(maps.only_objects_clearance_map, new_position, maps.map_info);
     if (!clearance || !obj_clearance) {
-      *clearance = 0;
-      *obj_clearance = 0;
+      clearance.emplace(0);
+      obj_clearance.emplace(0);
     }
     if (!enable_avoidance) {
       *obj_clearance = std::numeric_limits<double>::max();

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -1209,7 +1209,7 @@ double MPTOptimizer::getTraversedDistance(
       obj_clearance.emplace(0);
     }
     if (!enable_avoidance) {
-      *obj_clearance = std::numeric_limits<double>::max();
+      obj_clearance.emplace(std::numeric_limits<double>::max());
     }
     if (search_expanding_side) {
       if (clearance.get() > min_road_clearance && obj_clearance.get() > min_obj_clearance) {

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -800,7 +800,7 @@ boost::optional<std::vector<double>> MPTOptimizer::getRoughBound(
     return boost::none;
   }
   if (!enable_avoidance) {
-    *original_object_clearance = std::numeric_limits<double>::max();
+    original_object_clearance.emplace(std::numeric_limits<double>::max());
   }
   constexpr double min_road_clearance = 0.1;
   constexpr double min_obj_clearance = 0.1;


### PR DESCRIPTION
The process has died during a simple test in planing_simulation at Kashiwanoha.
Please check if finishing the simple test in planning_simulation.