### PR TITLE
Ros2 v0.8.0 fix packages

### DIFF
--- a/control/trajectory_follower/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/trajectory_follower/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -162,7 +162,7 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
   sub_twist_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
     "input/twist", 1, std::bind(&LaneDepartureCheckerNode::onTwist, this, _1));
   sub_lanelet_map_bin_ = this->create_subscription<autoware_lanelet2_msgs::msg::MapBin>(
-    "input/lanelet_map_bin", 1, std::bind(&LaneDepartureCheckerNode::onLaneletMapBin, this, _1));
+    "input/lanelet_map_bin",rclcpp::QoS{1}.transient_local(), std::bind(&LaneDepartureCheckerNode::onLaneletMapBin, this, _1));
   sub_route_ = this->create_subscription<autoware_planning_msgs::msg::Route>(
     "input/route", 1, std::bind(&LaneDepartureCheckerNode::onRoute, this, _1));
   sub_reference_trajectory_ = this->create_subscription<autoware_planning_msgs::msg::Trajectory>(

--- a/control/trajectory_follower/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/trajectory_follower/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -162,7 +162,8 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
   sub_twist_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
     "input/twist", 1, std::bind(&LaneDepartureCheckerNode::onTwist, this, _1));
   sub_lanelet_map_bin_ = this->create_subscription<autoware_lanelet2_msgs::msg::MapBin>(
-    "input/lanelet_map_bin",rclcpp::QoS{1}.transient_local(), std::bind(&LaneDepartureCheckerNode::onLaneletMapBin, this, _1));
+    "input/lanelet_map_bin", rclcpp::QoS{1}.transient_local(),
+    std::bind(&LaneDepartureCheckerNode::onLaneletMapBin, this, _1));
   sub_route_ = this->create_subscription<autoware_planning_msgs::msg::Route>(
     "input/route", 1, std::bind(&LaneDepartureCheckerNode::onRoute, this, _1));
   sub_reference_trajectory_ = this->create_subscription<autoware_planning_msgs::msg::Trajectory>(

--- a/control/vehicle_cmd_gate/CMakeLists.txt
+++ b/control/vehicle_cmd_gate/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(rclcpp REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(diagnostic_updater REQUIRED)
+find_package(vehicle_info_util REQUIRED)
 
 # Add path of include dir
 include_directories(include)
@@ -34,6 +35,7 @@ set(VEHICLE_CMD_GATE_DEPENDENCIES
   std_srvs
   geometry_msgs
   diagnostic_updater
+  vehicle_info_util
 )
 ament_target_dependencies(vehicle_cmd_gate ${VEHICLE_CMD_GATE_DEPENDENCIES})
 ament_export_dependencies(${VEHICLE_CMD_GATE_DEPENDENCIES})

--- a/control/vehicle_cmd_gate/CMakeLists.txt
+++ b/control/vehicle_cmd_gate/CMakeLists.txt
@@ -13,48 +13,29 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 ### Dependencies
-find_package(ament_cmake REQUIRED)
-find_package(autoware_control_msgs REQUIRED)
-find_package(autoware_vehicle_msgs REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(std_srvs REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(diagnostic_updater REQUIRED)
-find_package(vehicle_info_util REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 # Add path of include dir
 include_directories(include)
 
 # Generate exe file
-add_executable(vehicle_cmd_gate src/vehicle_cmd_gate_node.cpp src/vehicle_cmd_gate.cpp src/vehicle_cmd_filter.cpp)
-
-set(VEHICLE_CMD_GATE_DEPENDENCIES
-	autoware_control_msgs
-	autoware_vehicle_msgs
-  rclcpp
-  std_srvs
-  geometry_msgs
-  diagnostic_updater
-  vehicle_info_util
+ament_auto_add_executable(vehicle_cmd_gate
+  src/vehicle_cmd_gate_node.cpp
+  src/vehicle_cmd_gate.cpp
+  src/vehicle_cmd_filter.cpp
 )
+
 ament_target_dependencies(vehicle_cmd_gate ${VEHICLE_CMD_GATE_DEPENDENCIES})
 ament_export_dependencies(${VEHICLE_CMD_GATE_DEPENDENCIES})
-
-install(
-  TARGETS vehicle_cmd_gate
-  DESTINATION lib/${PROJECT_NAME}
-)
-
-install(
-  DIRECTORY
-    launch
-    config
-  DESTINATION share/${PROJECT_NAME}
-)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package()
+ament_auto_package(
+  INSTALL_TO_SHARE
+    launch
+    config
+)

--- a/control/vehicle_cmd_gate/include/vehicle_cmd_gate/vehicle_cmd_gate.hpp
+++ b/control/vehicle_cmd_gate/include/vehicle_cmd_gate/vehicle_cmd_gate.hpp
@@ -28,6 +28,7 @@
 #include "autoware_vehicle_msgs/msg/steering.hpp"
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
 #include "autoware_vehicle_msgs/msg/vehicle_command.hpp"
+#include "vehicle_info_util/vehicle_info.hpp"
 
 #include "vehicle_cmd_gate/vehicle_cmd_filter.hpp"
 #include "std_srvs/srv/trigger.hpp"

--- a/control/vehicle_cmd_gate/package.xml
+++ b/control/vehicle_cmd_gate/package.xml
@@ -17,8 +17,7 @@
   <depend>vehicle_info_util</depend>
 
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/control/vehicle_cmd_gate/package.xml
+++ b/control/vehicle_cmd_gate/package.xml
@@ -14,6 +14,7 @@
   <depend>geometry_msgs</depend>
   <depend>std_srvs</depend>
   <depend>diagnostic_updater</depend>
+  <depend>vehicle_info_util</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -1,32 +1,16 @@
-/*
- *  Copyright (c) 2017, Tier IV, Inc.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- *  * Neither the name of Autoware nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// Copyright 2015-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <chrono>
 #include <functional>
@@ -83,8 +67,8 @@ VehicleCmdGate::VehicleCmdGate()
     "input/system_emergency", 1, std::bind(&VehicleCmdGate::onSystemEmergency, this, _1));
   external_emergency_stop_sub_ =
     this->create_subscription<autoware_control_msgs::msg::EmergencyMode>(
-      "input/external_emergency_stop", 1,
-      std::bind(&VehicleCmdGate::onExternalEmergencyStop, this, _1));
+    "input/external_emergency_stop", 1,
+    std::bind(&VehicleCmdGate::onExternalEmergencyStop, this, _1));
   gate_mode_sub_ = this->create_subscription<autoware_control_msgs::msg::GateMode>(
     "input/gate_mode", 1, std::bind(&VehicleCmdGate::onGateMode, this, _1));
   engage_sub_ = this->create_subscription<autoware_vehicle_msgs::msg::Engage>(
@@ -160,9 +144,10 @@ VehicleCmdGate::VehicleCmdGate()
 
   // Diagnostics Updater
   updater_.setHardwareID("vehicle_cmd_gate");
-  updater_.add("heartbeat", [](auto & stat) {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Alive");
-  });
+  updater_.add(
+    "heartbeat", [](auto & stat) {
+      stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Alive");
+    });
   updater_.add("emergency_stop_operation", this, &VehicleCmdGate::checkExternalEmergencyStop);
 
   // Timer
@@ -262,7 +247,7 @@ void VehicleCmdGate::onTimer()
 
     if (is_system_emergency_heartbeat_timeout_) {
       RCLCPP_WARN_THROTTLE(
-        get_logger(), *get_clock(), 1000/*ms*/, "system_emergency heartbeat is timeout.");
+        get_logger(), *get_clock(), 1000 /*ms*/, "system_emergency heartbeat is timeout.");
       publishEmergencyStopControlCommands();
       return;
     }
@@ -275,7 +260,7 @@ void VehicleCmdGate::onTimer()
 
     if (is_external_emergency_stop_heartbeat_timeout_) {
       RCLCPP_WARN_THROTTLE(
-        get_logger(), *get_clock(), 1000/*ms*/, "external_emergency_stop heartbeat is timeout.");
+        get_logger(), *get_clock(), 1000 /*ms*/, "external_emergency_stop heartbeat is timeout.");
       is_external_emergency_stop_ = true;
     }
   }
@@ -284,7 +269,7 @@ void VehicleCmdGate::onTimer()
   if (is_external_emergency_stop_) {
     if (!is_external_emergency_stop_heartbeat_timeout_) {
       RCLCPP_INFO_THROTTLE(
-        get_logger(), *get_clock(), 1000/*ms*/,
+        get_logger(), *get_clock(), 1000 /*ms*/,
         "Please call `clear_external_emergency_stop` service to clear state.");
     }
 

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -131,7 +131,7 @@ VehicleCmdGate::VehicleCmdGate()
     declare_parameter("external_emergency_stop_heartbeat_timeout", 0.5);
 
   // Vehicle Parameter
-  double wheel_base = declare_parameter("/vehicle_info/wheel_base", 2.79);
+  double wheel_base = vehicle_info_util::VehicleInfo::create(*this).wheel_base_m_;
   double vel_lim = declare_parameter("vel_lim", 25.0);
   double lon_acc_lim = declare_parameter("lon_acc_lim", 5.0);
   double lon_jerk_lim = declare_parameter("lon_jerk_lim", 5.0);

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include "rclcpp/rclcpp.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
+#include "vehicle_info_util/vehicle_info.hpp"
 #include "tf2_ros/transform_listener.h"
 #include "lanelet2_core/LaneletMap.h"
 #include "lanelet2_routing/RoutingGraph.h"

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/package.xml
@@ -18,6 +18,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>libopencv-dev</depend>
+  <depend>vehicle_info_util</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_changer.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_changer.cpp
@@ -100,9 +100,10 @@ void LaneChanger::init()
   parameters.use_predicted_path_outside_lanelet = declare_parameter(
     "use_predicted_path_outside_lanelet", true);
   parameters.use_all_predicted_path = declare_parameter("use_all_predicted_path", false);
-  parameters.vehicle_width = declare_parameter("/vehicle_info/vehicle_width", 2.8);
-  parameters.vehicle_length = declare_parameter("/vehicle_info/vehicle_length", 5.0);
-  parameters.base_link2front = declare_parameter("/vehicle_info/max_longitudinal_offset", 3.74);
+  auto vehicle_info(vehicle_info_util::VehicleInfo::create(*this));
+  parameters.vehicle_width = vehicle_info.vehicle_width_m_;
+  parameters.vehicle_length = vehicle_info.vehicle_length_m_;
+  parameters.base_link2front = vehicle_info.max_longitudinal_offset_m_;
   parameters.abort_lane_change_velocity_thresh = declare_parameter(
     "abort_lane_change_velocity_thresh", 0.5);
   parameters.abort_lane_change_angle_thresh = declare_parameter(

--- a/simulator/simple_planning_simulator/CMakeLists.txt
+++ b/simulator/simple_planning_simulator/CMakeLists.txt
@@ -14,16 +14,6 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-### Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter -Werror)
-endif()
-
 # Add path of include dir
 include_directories(include)
 

--- a/simulator/simple_planning_simulator/CMakeLists.txt
+++ b/simulator/simple_planning_simulator/CMakeLists.txt
@@ -11,16 +11,18 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 ### Dependencies
-find_package(ament_cmake REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_ros REQUIRED)
-find_package(autoware_debug_msgs REQUIRED)
-find_package(autoware_planning_msgs REQUIRED)
-find_package(autoware_control_msgs REQUIRED)
-find_package(autoware_vehicle_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter -Werror)
+endif()
 
 # Add path of include dir
 include_directories(include)
@@ -34,22 +36,7 @@ set(SIMPLE_PLANNING_SIMULATOR_SRC
   src/vehicle_model/sim_model_time_delay.cpp
   src/vehicle_model/sim_model_util.cpp
 )
-add_executable(simple_planning_simulator_exe src/simple_planning_simulator_node.cpp ${SIMPLE_PLANNING_SIMULATOR_SRC})
-
-# Add dependencies. use target_link_libaries() before Crystal
-set(SIMPLE_PLANNING_SIMULATOR_DEPENDENCIES
-  rclcpp
-  std_msgs
-  geometry_msgs
-  tf2
-  tf2_ros
-  autoware_debug_msgs
-  autoware_planning_msgs
-  autoware_control_msgs
-  autoware_vehicle_msgs
-)
-ament_target_dependencies(simple_planning_simulator_exe ${SIMPLE_PLANNING_SIMULATOR_DEPENDENCIES})
-
+ament_auto_add_executable(simple_planning_simulator_exe src/simple_planning_simulator_node.cpp ${SIMPLE_PLANNING_SIMULATOR_SRC})
 
 ## Install executables and/or libraries
 install(TARGETS simple_planning_simulator_exe
@@ -66,5 +53,10 @@ install(DIRECTORY config launch
   DESTINATION share/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 # set at the end of cmakelists
-ament_package()
+ament_auto_package()

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 Autoware Foundation
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,11 +19,17 @@
  * @date 2019.08.17
  */
 
-#ifndef SIMPLE_PLANNING_SIMULATOR_CORE_H_
-#define SIMPLE_PLANNING_SIMULATOR_CORE_H_
+#ifndef SIMPLE_PLANNING_SIMULATOR__SIMPLE_PLANNING_SIMULATOR_CORE_HPP_
+#define SIMPLE_PLANNING_SIMULATOR__SIMPLE_PLANNING_SIMULATOR_CORE_HPP_
+
+#include <memory>
+#include <random>
+#include <string>
 
 #include "rclcpp/rclcpp.hpp"
 
+#include "eigen3/Eigen/Core"
+#include "eigen3/Eigen/LU"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
@@ -31,9 +37,6 @@
 #include "tf2/utils.h"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/LU"
-#include <random>
 
 #include "autoware_debug_msgs/msg/float32_stamped.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
@@ -44,11 +47,11 @@
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
 #include "autoware_vehicle_msgs/msg/vehicle_command.hpp"
 
-#include "vehicle_info_util/vehicle_info.hpp"
 #include "simple_planning_simulator/vehicle_model/sim_model_constant_acceleration.hpp"
 #include "simple_planning_simulator/vehicle_model/sim_model_ideal.hpp"
 #include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 #include "simple_planning_simulator/vehicle_model/sim_model_time_delay.hpp"
+#include "vehicle_info_util/vehicle_info.hpp"
 
 class Simulator : public rclcpp::Node
 {
@@ -65,21 +68,29 @@ public:
 
 private:
   /* ros system */
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_pose_;   //!< @brief topic ros publisher for current pose
-  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr pub_twist_;  //!< @brief topic ros publisher for current twist
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr
+    pub_pose_;  //!< @brief topic ros publisher for current pose
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr
+    pub_twist_;  //!< @brief topic ros publisher for current twist
   rclcpp::Publisher<autoware_vehicle_msgs::msg::Steering>::SharedPtr pub_steer_;
   rclcpp::Publisher<autoware_debug_msgs::msg::Float32Stamped>::SharedPtr pub_velocity_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr pub_turn_signal_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::ShiftStamped>::SharedPtr pub_shift_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::ControlMode>::SharedPtr pub_control_mode_;
 
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::VehicleCommand>::SharedPtr sub_vehicle_cmd_;      //!< @brief topic subscriber for vehicle_cmd
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr sub_turn_signal_cmd_;  //!< @brief topic subscriber for turn_signal_cmd
-  rclcpp::Subscription<autoware_planning_msgs::msg::Trajectory>::SharedPtr sub_trajectory_;   //!< @brief topic subscriber for trajectory used for z ppsition
-  rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr sub_initialpose_;  //!< @brief topic subscriber for initialpose topic
-  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_initialtwist_;  //!< @brief topic subscriber for initialtwist topic
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::Engage>::SharedPtr sub_engage_;        //!< @brief topic subscriber for engage topic
-  rclcpp::TimerBase::SharedPtr timer_simulation_;       //!< @brief timer for simulation
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::VehicleCommand>::SharedPtr
+    sub_vehicle_cmd_;  //!< @brief topic subscriber for vehicle_cmd
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr
+    sub_turn_signal_cmd_;  //!< @brief topic subscriber for turn_signal_cmd
+  rclcpp::Subscription<autoware_planning_msgs::msg::Trajectory>::SharedPtr
+    sub_trajectory_;  //!< @brief topic subscriber for trajectory used for z ppsition
+  rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
+    sub_initialpose_;  //!< @brief topic subscriber for initialpose topic
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr
+    sub_initialtwist_;  //!< @brief topic subscriber for initialtwist topic
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::Engage>::SharedPtr
+    sub_engage_;                                   //!< @brief topic subscriber for engage topic
+  rclcpp::TimerBase::SharedPtr timer_simulation_;  //!< @brief timer for simulation
 
   /* tf */
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
@@ -87,10 +98,12 @@ private:
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
 
   /* received & published topics */
-  geometry_msgs::msg::PoseStamped::ConstSharedPtr initial_pose_ptr_;  //!< @brief initial vehicle pose
+  geometry_msgs::msg::PoseStamped::ConstSharedPtr
+    initial_pose_ptr_;  //!< @brief initial vehicle pose
   geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr
-    initial_pose_with_cov_ptr_;                            //!< @brief initial vehicle pose with cov
-  geometry_msgs::msg::TwistStamped::ConstSharedPtr initial_twist_ptr_;  //!< @brief initial vehicle velocity
+    initial_pose_with_cov_ptr_;  //!< @brief initial vehicle pose with cov
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr
+    initial_twist_ptr_;                      //!< @brief initial vehicle velocity
   geometry_msgs::msg::Pose current_pose_;    //!< @brief current vehicle position and angle
   geometry_msgs::msg::Twist current_twist_;  //!< @brief current vehicle velocity
   autoware_vehicle_msgs::msg::VehicleCommand::ConstSharedPtr
@@ -112,10 +125,10 @@ private:
   double sim_steering_gear_ratio_;  //!< @brief for steering wheel angle calcultion
 
   /* flags */
-  bool is_initialized_ = false;         //!< @brief flag to check the initial position is set
-  bool add_measurement_noise_;  //!< @brief flag to add measurement noise
-  bool simulator_engage_;       //!< @brief flag to engage simulator
-  bool use_trajectory_for_z_position_source_; //!< @brief flag to get z positon from trajectory
+  bool is_initialized_ = false;                //!< @brief flag to check the initial position is set
+  bool add_measurement_noise_;                 //!< @brief flag to add measurement noise
+  bool simulator_engage_;                      //!< @brief flag to engage simulator
+  bool use_trajectory_for_z_position_source_;  //!< @brief flag to get z positon from trajectory
 
   /* saved values */
   std::shared_ptr<rclcpp::Time> prev_update_time_ptr_;  //!< @brief previously updated time
@@ -205,8 +218,7 @@ private:
    * @param [in] twist initial velocity and angular velocity
    */
   void setInitialState(
-    const geometry_msgs::msg::Pose & pose,
-    const geometry_msgs::msg::Twist & twist);
+    const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Twist & twist);
 
   /**
    * @brief set initial state of simulated vehicle with pose transformation based on frame_id
@@ -231,8 +243,7 @@ private:
    * @param [in] twist twist to be published
    */
   void publishPoseTwist(
-    const geometry_msgs::msg::Pose & pose,
-    const geometry_msgs::msg::Twist & twist);
+    const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Twist & twist);
 
   /**
    * @brief publish tf
@@ -255,4 +266,4 @@ private:
     const double & roll, const double & pitch, const double & yaw);
 };
 
-#endif
+#endif  // SIMPLE_PLANNING_SIMULATOR__SIMPLE_PLANNING_SIMULATOR_CORE_HPP_

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -44,6 +44,7 @@
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
 #include "autoware_vehicle_msgs/msg/vehicle_command.hpp"
 
+#include "vehicle_info_util/vehicle_info.hpp"
 #include "simple_planning_simulator/vehicle_model/sim_model_constant_acceleration.hpp"
 #include "simple_planning_simulator/vehicle_model/sim_model_ideal.hpp"
 #include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_constant_acceleration.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_constant_acceleration.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 Autoware Foundation
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,19 +14,20 @@
 
 /**
  * @file sim_model_constant_acceleration.hpp
- * @brief simple planning simulator model with constant acceleration for velocity & steeiring
+ * @brief simple planning simulator model with constant acceleration for velocity & steering
  * @author Takamasa Horibe
  * @date 2019.08.17
  */
 
-#ifndef SIMPLE_PLANNING_SIMULATOR_SIM_MODEL_CONSTANT_ACCELERATION_H_
-#define SIMPLE_PLANNING_SIMULATOR_SIM_MODEL_CONSTANT_ACCELERATION_H_
+#ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_CONSTANT_ACCELERATION_HPP_
+#define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_CONSTANT_ACCELERATION_HPP_
+
+#include <iostream>
 
 #include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/LU"
-#include <iostream>
 
 /**
  * @class simple_planning_simulator constant acceleration twist model
@@ -113,4 +114,4 @@ private:
   Eigen::VectorXd calcModel(const Eigen::VectorXd & state, const Eigen::VectorXd & input) override;
 };
 
-#endif
+#endif  // SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_CONSTANT_ACCELERATION_HPP_

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 Autoware Foundation
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,14 +20,15 @@
  * @date 2019.08.17
  */
 
-#ifndef SIMPLE_PLANNING_SIMULATOR_SIM_MODEL_IDEAL_H_
-#define SIMPLE_PLANNING_SIMULATOR_SIM_MODEL_IDEAL_H_
+#ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_HPP_
+#define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_HPP_
+
+#include <iostream>
 
 #include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/LU"
-#include <iostream>
 
 /**
  * @class simple_planning_simulator ideal twist model
@@ -114,7 +115,7 @@ public:
    * @brief constructor
    * @param [in] wheelbase vehicle wheelbase length [m]
    */
-  SimModelIdealSteer(double wheelbase);
+  explicit SimModelIdealSteer(double wheelbase);
 
   /**
    * @brief destructor
@@ -191,7 +192,7 @@ public:
    * @brief constructor
    * @param [in] wheelbase vehicle wheelbase length [m]
    */
-  SimModelIdealAccel(double wheelbase);
+  explicit SimModelIdealAccel(double wheelbase);
 
   /**
    * @brief destructor
@@ -258,4 +259,4 @@ private:
   Eigen::VectorXd calcModel(const Eigen::VectorXd & state, const Eigen::VectorXd & input) override;
 };
 
-#endif
+#endif  // SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_HPP_

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_interface.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_interface.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Autoware Foundation
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
  * @date 2019.08.17
  */
 
-#ifndef SIMPLE_PLANNING_SIMULATOR_SIM_MODEL_INTERFACE_H_
-#define SIMPLE_PLANNING_SIMULATOR_SIM_MODEL_INTERFACE_H_
+#ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_INTERFACE_HPP_
+#define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_INTERFACE_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 #include "eigen3/Eigen/Core"
@@ -133,4 +133,4 @@ public:
     const Eigen::VectorXd & state, const Eigen::VectorXd & input) = 0;
 };
 
-#endif
+#endif  // SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_INTERFACE_HPP_

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_time_delay.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_time_delay.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 Autoware Foundation
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,17 +19,18 @@
  * @date 2019.08.17
  */
 
-#ifndef SIMPLE_PLANNING_SIMULATOR_SIM_MODEL_TIME_DELAY_H_
-#define SIMPLE_PLANNING_SIMULATOR_SIM_MODEL_TIME_DELAY_H_
+#ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_TIME_DELAY_HPP_
+#define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_TIME_DELAY_HPP_
+
+#include <iostream>
+#include <queue>
+#include <deque>
 
 #include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 #include "simple_planning_simulator/vehicle_model/sim_model_util.hpp"
 
-#include <deque>
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/LU"
-#include <iostream>
-#include <queue>
 
 /**
  * @class simple_planning_simulator time delay twist model
@@ -360,4 +361,4 @@ private:
   Eigen::VectorXd calcModel(const Eigen::VectorXd & state, const Eigen::VectorXd & input) override;
 };
 
-#endif
+#endif  // SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_TIME_DELAY_HPP_

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_util.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_util.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_UTIL_HPP_
+#define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_UTIL_HPP_
+
 #include <math.h>
 
 namespace sim_model_util
@@ -18,3 +22,5 @@ namespace sim_model_util
 double getDummySteerCommandWithFriction(
   const double steer, const double steer_command, const double deadzone_delta_steer);
 }
+
+#endif  // SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_UTIL_HPP_

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -15,7 +15,6 @@
 from launch import LaunchContext
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-# from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackage

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -1,7 +1,21 @@
+# Copyright 2020 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from launch import LaunchContext
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.conditions import IfCondition
+# from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackage
@@ -10,17 +24,20 @@ from pathlib import Path
 import os
 
 
-
 context = LaunchContext()
 
 
 def find_pack(package_name):
     """Return the absolute path to the share directory of the given package."""
-    return os.path.join(Path(FindPackage(package_name).perform(context)), 'share', package_name)
+    return os.path.join(
+        Path(FindPackage(package_name).perform(context)), 'share', package_name)
+
 
 def generate_launch_description():
 
-    simple_planning_simulator_param_file = os.path.join(find_pack('simple_planning_simulator'), 'config/simple_planning_simulator.param.yaml')
+    simple_planning_simulator_param_file = os.path.join(
+        find_pack('simple_planning_simulator'),
+        'config/simple_planning_simulator.param.yaml')
 
     print(simple_planning_simulator_param_file)
 
@@ -40,8 +57,7 @@ def generate_launch_description():
         node_name='simple_planning_simulator',
         node_namespace='simulation',
         output='screen',
-        parameters=
-        [
+        parameters=[
             LaunchConfiguration('simple_planning_simulator_param_file'),
             LaunchConfiguration('vehicle_param_file'),
         ],
@@ -58,7 +74,6 @@ def generate_launch_description():
             ('input/engage', '/vehicle/engage'),
         ]
     )
-
 
     return LaunchDescription([
         simple_planning_simulator_param,

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -29,6 +29,10 @@ def generate_launch_description():
         default_value=simple_planning_simulator_param_file,
         description='Path to config file for simple_planning_simulator'
     )
+    vehicle_param_file_param = DeclareLaunchArgument(
+        'vehicle_param_file',
+        description='Path to config file for vehicle param'
+    )
 
     simple_planning_simulator = Node(
         package='simple_planning_simulator',
@@ -36,11 +40,10 @@ def generate_launch_description():
         node_name='simple_planning_simulator',
         node_namespace='simulation',
         output='screen',
-        parameters=[LaunchConfiguration('simple_planning_simulator_param_file'),
-            {
-                "/vehicle_info/wheel_base": 4.0,
-                "random_seed": 1
-            }
+        parameters=
+        [
+            LaunchConfiguration('simple_planning_simulator_param_file'),
+            LaunchConfiguration('vehicle_param_file'),
         ],
         remappings=[
             ('base_trajectory', '/planning/scenario_planning/trajectory'),
@@ -59,5 +62,6 @@ def generate_launch_description():
 
     return LaunchDescription([
         simple_planning_simulator_param,
+        vehicle_param_file_param,
         simple_planning_simulator
     ])

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.xml
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.xml
@@ -9,6 +9,7 @@
 
   <!-- model parameters -->
   <arg name="simulator_model" default="$(find-pkg-share simple_planning_simulator)/config/simple_planning_simulator.param.yaml"/>
+  <arg name="vehicle_param_file"/>
 
   <!-- simple_planning_simulator node -->
   <node pkg="simple_planning_simulator" exec="simple_planning_simulator_exe" name="simple_planning_simulator" output="screen">
@@ -24,6 +25,7 @@
     <remap from="input/engage" to="/vehicle/engage" />
 
     <param from="$(var simulator_model)"/>
+    <param from="$(var vehicle_param_file)"/>
 
     <param name="loop_rate" value="$(var loop_rate)"/>
     <param name="simulation_frame_id" value="$(var simulation_frame_id)"/>

--- a/simulator/simple_planning_simulator/package.xml
+++ b/simulator/simple_planning_simulator/package.xml
@@ -7,10 +7,10 @@
   <maintainer email="horibe.takamasa@gmail.com">Takamasa HORIBE</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclcpp_components</build_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2</depend>
@@ -19,12 +19,14 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>vehicle_info_util</depend>
 
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>topic_tools</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/simulator/simple_planning_simulator/scripts/fitParamDelayInputModel.py
+++ b/simulator/simple_planning_simulator/scripts/fitParamDelayInputModel.py
@@ -1,6 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import argparse
 import subprocess
@@ -10,24 +24,27 @@ from os.path import dirname, basename, splitext, join, exists
 try:
     import pandas as pd
 except ImportError:
-    print ('Please install pandas. See http://pandas.pydata.org/pandas-docs/stable/')
+    print('Please install pandas. See http://pandas.pydata.org/pandas-docs/stable/')
     sys.exit(1)
 
 FREQ_SAMPLE = 0.001
 
 # low pass filter
+
+
 def lowpass_filter(data, cutoff_freq=2, order=1, dt=FREQ_SAMPLE):
     tau = 1.0 / (2 * np.pi * cutoff_freq)
     for _ in range(order):
-        for i in range(1,len(data)):
-            data[i] = (tau / (tau + dt) * data[i-1] + dt / (tau + dt) * data[i])
+        for i in range(1, len(data)):
+            data[i] = (tau / (tau + dt) * data[i - 1] +
+                       dt / (tau + dt) * data[i])
     return data
 
+
 def rel2abs(path):
-    '''
-    Return absolute path from relative path input
-    '''
+    """Return absolute path from relative path input."""
     return join(getcwd(), path)
+
 
 def rosbag_to_csv(path, topic_name):
     name = splitext(basename(path))[0]
@@ -36,10 +53,12 @@ def rosbag_to_csv(path, topic_name):
     if exists(output_path):
         return output_path
     else:
-        command = "rostopic echo -b {0} -p /{1} | sed -e 's/,/ /g' > {2}".format(path, topic_name, output_path)
-        print (command)
+        command = "rostopic echo -b {0} -p /{1} | sed -e 's/,/ /g' > {2}".format(
+            path, topic_name, output_path)
+        print(command)
         subprocess.check_call(command, shell=True)
         return output_path
+
 
 def getActValue(df, speed_type):
     tm = np.array(list(df['%time'])) * 1e-9
@@ -52,21 +71,25 @@ def getActValue(df, speed_type):
     dval = (val[2:] - val[:-2]) / (tm[2:] - tm[:-2])
     return tm[1:-1], val[1:-1], dval
 
+
 def getCmdValueWithDelay(df, delay):
     tm = np.array(list(df['%time'])) * 1e-9
     val = np.array(list(df['field']))
     return tm + delay, val
+
 
 def getLinearInterpolate(_tm, _val, _index, ti):
     tmp_t = _tm[_index]
     tmp_nextt = _tm[_index + 1]
     tmp_val = _val[_index]
     tmp_nextval = _val[_index + 1]
-    val_i = tmp_val + (tmp_nextval - tmp_val) / (tmp_nextt - tmp_t) * (ti - tmp_t)
+    val_i = tmp_val + (tmp_nextval - tmp_val) / \
+        (tmp_nextt - tmp_t) * (ti - tmp_t)
     return val_i
 
-def getFittingTimeConstantParam(cmd_data, act_data, \
-                                delay, args, speed_type = False):
+
+def getFittingTimeConstantParam(cmd_data, act_data,
+                                delay, args, speed_type=False):
     tm_cmd, cmd_delay = getCmdValueWithDelay(cmd_data, delay)
     tm_act, act, dact = getActValue(act_data, speed_type)
     _t_min = max(tm_cmd[0], tm_act[0])
@@ -93,21 +116,30 @@ def getFittingTimeConstantParam(cmd_data, act_data, \
     diff_actcmd_samp = np.array(diff_actcmd_samp)
     if args.cutoff_freq > 0:
         dact_samp = lowpass_filter(dact_samp, cutoff_freq=args.cutoff_freq)
-        diff_actcmd_samp = lowpass_filter(diff_actcmd_samp, cutoff_freq=args.cutoff_freq)
-    dact_samp = dact_samp.reshape(1,-1)
-    diff_actcmd_samp = diff_actcmd_samp.reshape(1,-1)
-    tau = -np.dot(diff_actcmd_samp, np.linalg.pinv(dact_samp))[0,0]
-    error = np.linalg.norm(diff_actcmd_samp + tau * dact_samp) / dact_samp.shape[1]
+        diff_actcmd_samp = lowpass_filter(
+            diff_actcmd_samp, cutoff_freq=args.cutoff_freq)
+    dact_samp = dact_samp.reshape(1, -1)
+    diff_actcmd_samp = diff_actcmd_samp.reshape(1, -1)
+    tau = -np.dot(diff_actcmd_samp, np.linalg.pinv(dact_samp))[0, 0]
+    error = np.linalg.norm(diff_actcmd_samp + tau *
+                           dact_samp) / dact_samp.shape[1]
     return tau, error
 
-def getFittingParam(cmd_data, act_data, args, speed_type = False):
+
+def getFittingParam(cmd_data, act_data, args, speed_type=False):
     delay_range = int((args.max_delay - args.min_delay) / args.delay_incr)
-    delays = [args.min_delay + i * args.delay_incr for i in range(delay_range + 1)]
+    delays = [
+        args.min_delay +
+        i *
+        args.delay_incr for i in range(
+            delay_range +
+            1)]
     error_min = 1.0e10
     delay_opt = -1
     tau_opt = -1
     for delay in delays:
-        tau, error = getFittingTimeConstantParam(cmd_data, act_data, delay, args, speed_type=speed_type)
+        tau, error = getFittingTimeConstantParam(
+            cmd_data, act_data, delay, args, speed_type=speed_type)
         if tau > 0:
             if error < error_min:
                 error_min = error
@@ -117,23 +149,60 @@ def getFittingParam(cmd_data, act_data, args, speed_type = False):
             break
     return tau_opt, delay_opt, error_min
 
+
 if __name__ == '__main__':
-    topics = [ 'vehicle_cmd/ctrl_cmd/steering_angle', 'vehicle_status/angle', \
-               'vehicle_cmd/ctrl_cmd/linear_velocity', 'vehicle_status/speed']
+    topics = ['vehicle_cmd/ctrl_cmd/steering_angle', 'vehicle_status/angle',
+              'vehicle_cmd/ctrl_cmd/linear_velocity', 'vehicle_status/speed']
     pd_data = [None] * len(topics)
-    parser = argparse.ArgumentParser(description='Paramter fitting for Input Delay Model (First Order System with Dead Time) with rosbag file input')
-    parser.add_argument('--bag_file', '-b', required=True, type=str, help='rosbag file', metavar='file')
-    parser.add_argument('--cutoff_time', default=1.0, type=float, help='Cutoff time[sec], Parameter fitting will only consider data from t= cutoff_time to the end of the bag file (default is 1.0)')
-    parser.add_argument('--cutoff_freq', default=0.1, type=float, help='Cutoff freq for low-pass filter[Hz], negative value will disable low-pass filter (default is 0.1)')
-    parser.add_argument('--min_delay', default=0.1, type=float, help='Min value for searching delay loop (default is 0.1)')
-    parser.add_argument('--max_delay', default=1.0, type=float, help='Max value for searching delay loop (default is 1.0)')
-    parser.add_argument('--delay_incr', default=0.01, type=float, help='Step value for searching delay loop (default is 0.01)')
+    parser = argparse.ArgumentParser(
+        description='Paramter fitting for Input Delay Model'
+        ' (First Order System with Dead Time) with rosbag file input')
+    parser.add_argument(
+        '--bag_file',
+        '-b',
+        required=True,
+        type=str,
+        help='rosbag file',
+        metavar='file')
+    parser.add_argument(
+        '--cutoff_time',
+        default=1.0,
+        type=float,
+        help='Cutoff time[sec], Parameter fitting will only consider data '
+        'from t= cutoff_time to the end of the bag file (default is 1.0)')
+    parser.add_argument(
+        '--cutoff_freq',
+        default=0.1,
+        type=float,
+        help='Cutoff freq for low-pass filter[Hz], '
+        'negative value will disable low-pass filter (default is 0.1)')
+    parser.add_argument(
+        '--min_delay',
+        default=0.1,
+        type=float,
+        help='Min value for searching delay loop (default is 0.1)')
+    parser.add_argument(
+        '--max_delay',
+        default=1.0,
+        type=float,
+        help='Max value for searching delay loop (default is 1.0)')
+    parser.add_argument(
+        '--delay_incr',
+        default=0.01,
+        type=float,
+        help='Step value for searching delay loop (default is 0.01)')
     args = parser.parse_args()
 
     for i, topic in enumerate(topics):
         csv_log = rosbag_to_csv(rel2abs(args.bag_file), topic)
         pd_data[i] = pd.read_csv(csv_log, sep=' ')
-    tau_opt, delay_opt, error = getFittingParam(pd_data[0], pd_data[1], args, speed_type=False)
-    print ('Steer angle: tau_opt = %2.4f, delay_opt = %2.4f, error = %2.4e' %(tau_opt, delay_opt, error))
-    tau_opt, delay_opt, error = getFittingParam(pd_data[2], pd_data[3], args, speed_type=True)
-    print ('Velocity   : tau_opt = %2.4f, delay_opt = %2.4f, error = %2.4e' %(tau_opt, delay_opt, error))
+    tau_opt, delay_opt, error = getFittingParam(
+        pd_data[0], pd_data[1], args, speed_type=False)
+    print(
+        'Steer angle: tau_opt = %2.4f, delay_opt = %2.4f, error = %2.4e' %
+        (tau_opt, delay_opt, error))
+    tau_opt, delay_opt, error = getFittingParam(
+        pd_data[2], pd_data[3], args, speed_type=True)
+    print(
+        'Velocity   : tau_opt = %2.4f, delay_opt = %2.4f, error = %2.4e' %
+        (tau_opt, delay_opt, error))

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator_core.cpp
@@ -93,19 +93,19 @@ Simulator::Simulator(const std::string & node_name, const rclcpp::NodeOptions & 
   {
     auto vehicle_model_type_str = declare_parameter("vehicle_model_type", "IDEAL_STEER");
     RCLCPP_INFO(get_logger(), "vehicle_model_type = %s", vehicle_model_type_str.c_str());
-    auto tread_length = declare_parameter("tread_length", 2.0);
-    auto angvel_lim = declare_parameter("angvel_lim", 3.0);
+    // auto tread_length = declare_parameter("tread_length", 2.0);
+    // auto angvel_lim = declare_parameter("angvel_lim", 3.0);
     auto vel_lim = declare_parameter("vel_lim", 50.0);
     auto steer_lim = declare_parameter("steer_lim", 1.0);
     auto accel_rate = declare_parameter("accel_rate", 10.0);
-    auto angvel_rate = declare_parameter("angvel_rate", 1.0);
+    // auto angvel_rate = declare_parameter("angvel_rate", 1.0);
     auto steer_rate_lim = declare_parameter("steer_rate_lim", 5.0);
     auto vel_time_delay = declare_parameter("vel_time_delay", 0.25);
     auto vel_time_constant = declare_parameter("vel_time_constant", 0.5);
     auto steer_time_delay = declare_parameter("steer_time_delay", 0.3);
     auto steer_time_constant = declare_parameter("steer_time_constant", 0.3);
-    auto angvel_time_delay = declare_parameter("angvel_time_delay", 0.3);
-    auto angvel_time_constant = declare_parameter("angvel_time_constant", 0.3);
+    // auto angvel_time_delay = declare_parameter("angvel_time_delay", 0.3);
+    // auto angvel_time_constant = declare_parameter("angvel_time_constant", 0.3);
     auto acc_time_delay = declare_parameter("acc_time_delay", 0.1);
     auto acc_time_constant = declare_parameter("acc_time_constant", 0.1);
     simulator_engage_ = declare_parameter("initial_engage_state", true);

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator_core.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 Autoware Foundation
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+#include <memory>
+#include <utility>
 #include "simple_planning_simulator/simple_planning_simulator_core.hpp"
 
 Simulator::Simulator(const std::string & node_name, const rclcpp::NodeOptions & options)

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator_core.cpp
@@ -96,19 +96,14 @@ Simulator::Simulator(const std::string & node_name, const rclcpp::NodeOptions & 
   {
     auto vehicle_model_type_str = declare_parameter("vehicle_model_type", "IDEAL_STEER");
     RCLCPP_INFO(get_logger(), "vehicle_model_type = %s", vehicle_model_type_str.c_str());
-    // auto tread_length = declare_parameter("tread_length", 2.0);
-    // auto angvel_lim = declare_parameter("angvel_lim", 3.0);
     auto vel_lim = declare_parameter("vel_lim", 50.0);
     auto steer_lim = declare_parameter("steer_lim", 1.0);
     auto accel_rate = declare_parameter("accel_rate", 10.0);
-    // auto angvel_rate = declare_parameter("angvel_rate", 1.0);
     auto steer_rate_lim = declare_parameter("steer_rate_lim", 5.0);
     auto vel_time_delay = declare_parameter("vel_time_delay", 0.25);
     auto vel_time_constant = declare_parameter("vel_time_constant", 0.5);
     auto steer_time_delay = declare_parameter("steer_time_delay", 0.3);
     auto steer_time_constant = declare_parameter("steer_time_constant", 0.3);
-    // auto angvel_time_delay = declare_parameter("angvel_time_delay", 0.3);
-    // auto angvel_time_constant = declare_parameter("angvel_time_constant", 0.3);
     auto acc_time_delay = declare_parameter("acc_time_delay", 0.1);
     auto acc_time_constant = declare_parameter("acc_time_constant", 0.1);
     simulator_engage_ = declare_parameter("initial_engage_state", true);

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator_core.cpp
@@ -18,8 +18,8 @@ Simulator::Simulator(const std::string & node_name, const rclcpp::NodeOptions & 
 : Node(node_name, options)
 {
   /* simple_planning_simulator parameters */
+  wheelbase_ = vehicle_info_util::VehicleInfo::create(*this).wheel_base_m_;
   loop_rate_ = declare_parameter("loop_rate", 30.0);
-  wheelbase_ = declare_parameter("vehicle_info.wheel_base", 4.0);
   sim_steering_gear_ratio_ = declare_parameter("sim_steering_gear_ratio", 15.0);
   simulation_frame_id_ = declare_parameter("simulation_frame_id", "base_link");
   map_frame_id_ = declare_parameter("map_frame_id", "map");

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator_node.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator_node.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 Autoware Foundation
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include "simple_planning_simulator/simple_planning_simulator_core.hpp"
 
 int main(int argc, char ** argv)

--- a/simulator/simple_planning_simulator/src/vehicle_model/sim_model_constant_acceleration.cpp
+++ b/simulator/simple_planning_simulator/src/vehicle_model/sim_model_constant_acceleration.cpp
@@ -1,18 +1,18 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
 
 #include "simple_planning_simulator/vehicle_model/sim_model_constant_acceleration.hpp"
 

--- a/simulator/simple_planning_simulator/src/vehicle_model/sim_model_ideal.cpp
+++ b/simulator/simple_planning_simulator/src/vehicle_model/sim_model_ideal.cpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "simple_planning_simulator/vehicle_model/sim_model_ideal.hpp"
 

--- a/simulator/simple_planning_simulator/src/vehicle_model/sim_model_interface.cpp
+++ b/simulator/simple_planning_simulator/src/vehicle_model/sim_model_interface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Autoware Foundation
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/simulator/simple_planning_simulator/src/vehicle_model/sim_model_time_delay.cpp
+++ b/simulator/simple_planning_simulator/src/vehicle_model/sim_model_time_delay.cpp
@@ -1,19 +1,17 @@
-/*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <algorithm>
 #include "simple_planning_simulator/vehicle_model/sim_model_time_delay.hpp"
 
 /*

--- a/simulator/simple_planning_simulator/src/vehicle_model/sim_model_util.cpp
+++ b/simulator/simple_planning_simulator/src/vehicle_model/sim_model_util.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2015-2020 Autoware Foundation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
+++ b/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
@@ -277,7 +277,8 @@ void AutowareStateMonitorNode::registerTopicCallback(
       &AutowareStateMonitorNode::onTopic, this, std::placeholders::_1,
       topic_name));
   sub_topic_map_[topic_name] = rclcpp_generic::GenericSubscription::create(
-    this->get_node_topics_interface(), topic_name, topic_type, rclcpp::QoS{1}, callback);
+    this->get_node_topics_interface(), topic_name, topic_type,
+    rclcpp::QoS{1}.transient_local(), callback);
 }
 
 TopicStats AutowareStateMonitorNode::getTopicStats() const


### PR DESCRIPTION
- Update the method of getting vehicle info
- Add latch option to vector-map subscriber / GenericSubscription used by autoware_state_monitor
 (The subscription of autoware_state_monitor includes vector-map / pointcloud map)

#How to check
```
$ros2 launch autoware_launch planning_simulator.launch.xml vehicle_model:=lexus vehicle_id:=default sensor_model:=aip_xx1 map_path:=[MAP PATH]
```
Check with merging the related PR https://github.com/tier4/autoware_launcher.iv.universe/pull/64

Item to check
- No following error message: [control.trajectory_follower.lane_departure_checker_node]: waiting for lanelet_map msg...
- No significant understeer on the curve


（*There are many changes in this PR, but most of them are related to lint correction.）


