### PR TITLE
rename vehicle_info_param to vehicle_param_file

### DIFF
--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/launch/obstacle_avoidance_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/launch/obstacle_avoidance_planner.launch.xml
@@ -5,7 +5,7 @@
   <arg name="is_showing_debug_info" default="false"/>
   <arg name="is_stopping_if_outside_drivable_area" default="true"/>
   <arg name="param_path" default="$(find-pkg-share obstacle_avoidance_planner)/config/obstacle_avoidance_planner.param.yaml" />
-  <arg name="vehicle_info_param" default="$(find-pkg-share lexus_description)/config/vehicle_info.param.yaml" />
+  <arg name="vehicle_param_file" default="$(find-pkg-share lexus_description)/config/vehicle_info.param.yaml" />
 
   <node pkg="obstacle_avoidance_planner" exec="obstacle_avoidance_planner_node"
     name="obstacle_avoidance_planner" output="screen">
@@ -14,7 +14,7 @@
     <remap from="output/path" to="$(var output_path_topic)" />
 
     <param from="$(var param_path)" />
-    <param from="$(var vehicle_info_param)" />
+    <param from="$(var vehicle_param_file)" />
     <param name="is_showing_debug_info" value="$(var is_showing_debug_info)"/>
     <param name="is_stopping_if_outside_drivable_area" value="$(var is_stopping_if_outside_drivable_area)"/>
   </node>

--- a/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <arg name="param_path" default="$(find-pkg-share surround_obstacle_checker)/config/surround_obstacle_checker.param.yaml" />
-  <arg name="vehicle_info_param" default="$(find-pkg-share lexus_description)/config/vehicle_info.param.yaml" />
+  <arg name="vehicle_param_file" default="$(find-pkg-share lexus_description)/config/vehicle_info.param.yaml" />
 
   <arg name="input_trajectory" default="input/trajectory" />
   <arg name="input_objects" default="/perception/object_recognition/objects" />
@@ -10,7 +10,7 @@
 
   <node pkg="surround_obstacle_checker" exec="surround_obstacle_checker_node" name="surround_obstacle_checker" output="screen">
     <param from="$(var param_path)" />
-    <param from="$(var vehicle_info_param)" />
+    <param from="$(var vehicle_param_file)" />
     <remap from="output/no_start_reason" to="/planning/scenario_planning/status/no_start_reason" />
     <remap from="output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons" />
     <remap from="output/trajectory" to="$(var output_trajectory)" />

--- a/vehicle/as/launch/pacmod_interface.launch.xml
+++ b/vehicle/as/launch/pacmod_interface.launch.xml
@@ -3,12 +3,12 @@
 
   <arg name="pacmod_param_path" default="$(find-pkg-share as)/config/pacmod.param.yaml"/>
 
-  <arg name="vehicle_info_param" default="$(find-pkg-share lexus_description)/config/vehicle_info.param.yaml" />
+  <arg name="vehicle_param_file" default="$(find-pkg-share lexus_description)/config/vehicle_info.param.yaml" />
 
   <!-- pacmod interface -->
   <node pkg="as" exec="pacmod_interface" name="pacmod_interface" output="screen">
     <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
-    <param from="$(var vehicle_info_param)" />
+    <param from="$(var vehicle_param_file)" />
     <param from="$(var pacmod_param_path)" />
   </node>
 


### PR DESCRIPTION
Almost other packages use `vehicle_param_file`, 
but several packages use `vehicle_info_param`.
So this pr aims to make a consistent expression to `vechile_param_file` 