### PR TITLE
Ros2 v0.8.0 fix packages2

### DIFF
--- a/system/autoware_error_monitor/config/diagnostic_aggregator/sensing.param.yaml
+++ b/system/autoware_error_monitor/config/diagnostic_aggregator/sensing.param.yaml
@@ -20,89 +20,93 @@
           type: 'diagnostic_aggregator/AnalyzerGroup'
           path: lidar
           analyzers:
-            connection:
-              type: diagnostic_aggregator/GenericAnalyzer
-              path: connection
-              contains: [": velodyne_connection"]
-              timeout: 3.0
-              num_items: 0
-            temperature:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: temperature
-              contains: [": velodyne_temperature"]
-              timeout: 3.0
-              num_items: 0
-            rpm:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: rpm
-              contains: [": velodyne_rpm"]
-              timeout: 3.0
-              num_items: 0
+            velodyne:
+              type: diagnostic_aggregator/AnalyzerGroup
+              path: velodyne
+              analyzers:
+                connection:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: connection
+                  contains: [": velodyne_connection"]
+                  timeout: 3.0
+                  num_items: 0
+                temperature:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: temperature
+                  contains: [": velodyne_temperature"]
+                  timeout: 3.0
+                  num_items: 0
+                rpm:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: rpm
+                  contains: [": velodyne_rpm"]
+                  timeout: 3.0
+                  num_items: 0
 
-        livox:
-          type: 'diagnostic_aggregator/AnalyzerGroup'
-          path: livox
-          analyzers:
-            connection:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: connection
-              contains: [": livox_connection"]
-              timeout: 3.0
-              num_items: 0
-            temperature:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: temperature
-              contains: [": livox_temperature"]
-              timeout: 3.0
-              num_items: 0
-            internal_voltage:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: internal_voltage
-              contains: [": livox_internal_voltage"]
-              timeout: 3.0
-              num_items: 0
-            motor_status:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: motor_status
-              contains: [": livox_motor_status"]
-              timeout: 3.0
-              num_items: 0
-            firmware_staus:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: firmware_staus
-              contains: [": livox_firmware_staus"]
-              timeout: 3.0
-              num_items: 0
-            pps_signal:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: pps_signal
-              contains: [": livox_pps_signal"]
-              timeout: 3.0
-              num_items: 0
-            service_life:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: service_life
-              contains: [": livox_service_life"]
-              timeout: 3.0
-              num_items: 0
-            fan_status:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: fan_status
-              contains: [": livox_fan_status"]
-              timeout: 3.0
-              num_items: 0
-            ptp_signal:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: ptp_signal
-              contains: [": livox_ptp_signal"]
-              timeout: 3.0
-              num_items: 0
-            time_sync:
-              type: 'diagnostic_aggregator/GenericAnalyzer'
-              path: time_sync
-              contains: [": livox_time_sync"]
-              timeout: 3.0
-              num_items: 0
+            livox:
+              type: 'diagnostic_aggregator/AnalyzerGroup'
+              path: livox
+              analyzers:
+                connection:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: connection
+                  contains: [": livox_connection"]
+                  timeout: 3.0
+                  num_items: 0
+                temperature:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: temperature
+                  contains: [": livox_temperature"]
+                  timeout: 3.0
+                  num_items: 0
+                internal_voltage:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: internal_voltage
+                  contains: [": livox_internal_voltage"]
+                  timeout: 3.0
+                  num_items: 0
+                motor_status:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: motor_status
+                  contains: [": livox_motor_status"]
+                  timeout: 3.0
+                  num_items: 0
+                firmware_staus:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: firmware_staus
+                  contains: [": livox_firmware_staus"]
+                  timeout: 3.0
+                  num_items: 0
+                pps_signal:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: pps_signal
+                  contains: [": livox_pps_signal"]
+                  timeout: 3.0
+                  num_items: 0
+                service_life:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: service_life
+                  contains: [": livox_service_life"]
+                  timeout: 3.0
+                  num_items: 0
+                fan_status:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: fan_status
+                  contains: [": livox_fan_status"]
+                  timeout: 3.0
+                  num_items: 0
+                ptp_signal:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: ptp_signal
+                  contains: [": livox_ptp_signal"]
+                  timeout: 3.0
+                  num_items: 0
+                time_sync:
+                  type: 'diagnostic_aggregator/GenericAnalyzer'
+                  path: time_sync
+                  contains: [": livox_time_sync"]
+                  timeout: 3.0
+                  num_items: 0
 
         camera:
           type: 'diagnostic_aggregator/AnalyzerGroup'

--- a/system/autoware_error_monitor/config/diagnostic_aggregator/sensing.param.yaml
+++ b/system/autoware_error_monitor/config/diagnostic_aggregator/sensing.param.yaml
@@ -18,7 +18,7 @@
 
         lidar:
           type: 'diagnostic_aggregator/AnalyzerGroup'
-          path: velodyne
+          path: lidar
           analyzers:
             connection:
               type: diagnostic_aggregator/GenericAnalyzer

--- a/system/autoware_state_monitor/config/autoware_state_monitor.param.yaml
+++ b/system/autoware_state_monitor/config/autoware_state_monitor.param.yaml
@@ -43,12 +43,14 @@
           timeout: 0.0
           warn_rate: 0.0
           type: "autoware_lanelet2_msgs/msg/MapBin"
+          transient_local: True
 
         /map/pointcloud_map:
           module: "map"
           timeout: 0.0
           warn_rate: 0.0
           type: "sensor_msgs/msg/PointCloud2"
+          transient_local: True
 
         /sensing/lidar/pointcloud:
           module: "sensing"

--- a/system/autoware_state_monitor/config/autoware_state_monitor.param.yaml
+++ b/system/autoware_state_monitor/config/autoware_state_monitor.param.yaml
@@ -93,6 +93,7 @@
           timeout: 0.0
           warn_rate: 0.0
           type: "autoware_planning_msgs/msg/Route"
+          transient_local: True
 
         /planning/scenario_planning/trajectory:
           module: "planning"

--- a/system/autoware_state_monitor/config/autoware_state_monitor.planning_simulation.param.yaml
+++ b/system/autoware_state_monitor/config/autoware_state_monitor.planning_simulation.param.yaml
@@ -65,7 +65,7 @@
           timeout: 0.0
           warn_rate: 0.0
           type: "autoware_planning_msgs/msg/Route"
-          latch: True
+          transient_local: True
 
         /planning/scenario_planning/trajectory:
           module: "planning"

--- a/system/autoware_state_monitor/config/autoware_state_monitor.planning_simulation.param.yaml
+++ b/system/autoware_state_monitor/config/autoware_state_monitor.planning_simulation.param.yaml
@@ -39,12 +39,14 @@
           timeout: 0.0
           warn_rate: 0.0
           type: "autoware_lanelet2_msgs/msg/MapBin"
+          transient_local: True
 
         /map/pointcloud_map:
           module: "map"
           timeout: 0.0
           warn_rate: 0.0
           type: "sensor_msgs/msg/PointCloud2"
+          transient_local: True
 
         /perception/object_recognition/objects:
           module: "perception"
@@ -63,6 +65,7 @@
           timeout: 0.0
           warn_rate: 0.0
           type: "autoware_planning_msgs/msg/Route"
+          latch: True
 
         /planning/scenario_planning/trajectory:
           module: "planning"

--- a/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state_monitor_node.hpp
+++ b/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state_monitor_node.hpp
@@ -80,7 +80,7 @@ private:
   void onTopic(
     const std::shared_ptr<rclcpp::SerializedMessage> msg, const std::string & topic_name);
   void registerTopicCallback(
-    const std::string & topic_name, const std::string & topic_type);
+    const std::string & topic_name, const std::string & topic_type, const bool transient_local);
 
   std::map<std::string, rclcpp_generic::GenericSubscription::SharedPtr> sub_topic_map_;
   std::map<std::string, std::deque<rclcpp::Time>> topic_received_time_buffer_;

--- a/system/autoware_state_monitor/include/autoware_state_monitor/config.hpp
+++ b/system/autoware_state_monitor/include/autoware_state_monitor/config.hpp
@@ -19,8 +19,8 @@
 #include <utility>
 #include <vector>
 
-#include "rclcpp/time.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp/time.hpp"
 
 struct TopicConfig
 {
@@ -30,6 +30,9 @@ struct TopicConfig
   : module(interface->declare_parameter(namespace_prefix + ".module").get<std::string>()),
     name(name),
     type(interface->declare_parameter(namespace_prefix + ".type").get<std::string>()),
+    transient_local(
+      interface->declare_parameter(namespace_prefix + ".transient_local",
+      static_cast<rclcpp::ParameterValue>(false)).get<bool>()),
     timeout(interface->declare_parameter(namespace_prefix + ".timeout").get<double>()),
     warn_rate(interface->declare_parameter(namespace_prefix + ".warn_rate").get<double>())
   {
@@ -38,6 +41,7 @@ struct TopicConfig
   std::string module;
   std::string name;
   std::string type;
+  bool transient_local;
   double timeout;
   double warn_rate;
 };
@@ -80,7 +84,7 @@ struct TopicStats
   std::vector<TopicConfig> ok_list;
   std::vector<TopicConfig> non_received_list;
   std::vector<std::pair<TopicConfig, rclcpp::Time>> timeout_list;  // pair<TfConfig, last_received>
-  std::vector<std::pair<TopicConfig, double>> slow_rate_list;   // pair<TfConfig, rate>
+  std::vector<std::pair<TopicConfig, double>> slow_rate_list;      // pair<TfConfig, rate>
 };
 
 struct ParamStats

--- a/system/emergency_handler/launch/emergency_handler.launch.xml
+++ b/system/emergency_handler/launch/emergency_handler.launch.xml
@@ -5,7 +5,7 @@
   <arg name="input_prev_control_command" default="/control/vehicle_cmd" />
   <arg name="input_current_gate_mode" default="/control/current_gate_mode" />
   <arg name="input_twist" default="/localization/twist" />
-  <arg name="input_is_state_timeout" default="state_timeout_checker/is_state_timeout" />
+  <arg name="input_is_state_timeout" default="is_state_timeout" />
 
   <arg name="output_control_command" default="/system/emergency/control_cmd" />
   <arg name="output_shift" default="/system/emergency/shift_cmd" />

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -136,7 +136,7 @@ EmergencyHandler::EmergencyHandler()
   initialized_time_ = this->now();
   auto timer_callback = std::bind(&EmergencyHandler::onTimer, this);
   auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
-    std::chrono::duration<double>(update_rate_));
+    std::chrono::duration<double>(1.0 / update_rate_));
 
   timer_ = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
     this->get_clock(), period, std::move(timer_callback),

--- a/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
+++ b/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
@@ -39,7 +39,7 @@ StateTimeoutChecker::StateTimeoutChecker()
   // Timer
   auto timer_callback = std::bind(&StateTimeoutChecker::onTimer, this);
   auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
-    std::chrono::duration<double>(update_rate_));
+    std::chrono::duration<double>(1.0 / update_rate_));
 
   timer_ = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
     this->get_clock(), period, std::move(timer_callback),

--- a/vehicle/remote_cmd_converter/launch/remote_cmd_converter.launch.xml
+++ b/vehicle/remote_cmd_converter/launch/remote_cmd_converter.launch.xml
@@ -21,7 +21,7 @@
 
     <remap from="in/raw_control_cmd" to="/remote/raw_control_cmd" />
     <remap from="in/shift_cmd" to="/remote/shift_cmd" />
-    <remap from="in/emergency" to="/remote/emergency" />
+    <remap from="in/emergency_stop" to="/remote/emergency_stop" />
     <remap from="in/current_gate_mode" to="/control/current_gate_mode" />
     <remap from="in/twist" to="/localization/twist" />
 


### PR DESCRIPTION
Fixed the cause of /autoware/state becoming Emergency

# How to check
```
$ros2 launch autoware_launch planning_simulator.launch.xml vehicle_model:=lexus vehicle_id:=default sensor_model:=aip_xx1 map_path:=[MAP_PATH]
Set initial pose and goal pose
$ros2 topic echo /autoware/state # check state
```

