### PR TITLE
fix implement miss in autoware_state_monitor

### DIFF
--- a/system/autoware_state_monitor/src/autoware_state_monitor_node/state_machine.cpp
+++ b/system/autoware_state_monitor/src/autoware_state_monitor_node/state_machine.cpp
@@ -276,6 +276,10 @@ AutowareState StateMachine::judgeAutowareState() const
           return AutowareState::Planning;
         }
 
+        if (isEngaged()) {
+          return AutowareState::Driving;
+        }
+
         if (hasArrivedGoal()) {
           times_.arrived_goal = state_input_.current_time;
           return AutowareState::ArrivedGoal;


### PR DESCRIPTION
Fixed an issue that Autoware state did not change from *waitingForEngage* when /autoware/engage:true is published

(implementing miss: https://github.com/tier4/AutowareArchitectureProposal.iv/blob/master/system/autoware_state_monitor/src/autoware_state_monitor_node/state_machine.cpp#L276-L278 )