### PR TITLE
Fix dependency of system_monitor

### DIFF
--- a/system/system_monitor/package.xml
+++ b/system/system_monitor/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
   <depend>rclcpp</depend>
   <depend>fmt</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
Fix compilation error
>AutowareArchitectureProposal.proj/src/autoware/AutowareArchitectureProposal.iv/system/system_monitor/include/system_monitor/cpu_monitor/cpu_monitor_base.hpp:28:10: fatal error: diagnostic_updater/diagnostic_updater.hpp: そのようなファイルやディレクトリはありません
   28 | #include "diagnostic_updater/diagnostic_updater.hpp"