### PR TITLE
replace std_msgs to timeout_notification_msgs

### DIFF
--- a/common/msgs/autoware_system_msgs/CMakeLists.txt
+++ b/common/msgs/autoware_system_msgs/CMakeLists.txt
@@ -19,6 +19,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/DrivingCapability.msg"
   "msg/HazardStatus.msg"
   "msg/HazardStatusStamped.msg"
+  "msg/TimeoutNotification.msg"
   DEPENDENCIES diagnostic_msgs std_msgs
 )
 

--- a/common/msgs/autoware_system_msgs/msg/TimeoutNotification.msg
+++ b/common/msgs/autoware_system_msgs/msg/TimeoutNotification.msg
@@ -1,0 +1,1 @@
+bool data

--- a/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
+++ b/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
@@ -54,7 +54,8 @@ private:
     sub_prev_control_command_;
   rclcpp::Subscription<autoware_control_msgs::msg::GateMode>::SharedPtr sub_current_gate_mode_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_twist_;
-  rclcpp::Subscription<autoware_system_msgs::msg::TimeoutNotification>::SharedPtr sub_is_state_timeout_;
+  rclcpp::Subscription<autoware_system_msgs::msg::TimeoutNotification>::SharedPtr
+    sub_is_state_timeout_;
 
   autoware_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_;
   autoware_system_msgs::msg::DrivingCapability::ConstSharedPtr driving_capability_;
@@ -112,7 +113,7 @@ private:
   std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::DrivingCapability>>
   heartbeat_driving_capability_;
   std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::TimeoutNotification>>
-    heartbeat_is_state_timeout_;
+  heartbeat_is_state_timeout_;
 
   // Algorithm
   bool is_emergency_ = false;

--- a/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
+++ b/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
@@ -26,6 +26,7 @@
 #include "autoware_system_msgs/msg/autoware_state.hpp"
 #include "autoware_system_msgs/msg/driving_capability.hpp"
 #include "autoware_system_msgs/msg/hazard_status_stamped.hpp"
+#include "autoware_system_msgs/msg/timeout_notification.hpp"
 #include "autoware_vehicle_msgs/msg/shift_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
 #include "autoware_vehicle_msgs/msg/vehicle_command.hpp"
@@ -33,7 +34,6 @@
 // ROS2 core
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "std_msgs/msg/bool.hpp"
 #include "std_srvs/srv/trigger.hpp"
 #include "rclcpp/create_timer.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -54,14 +54,14 @@ private:
     sub_prev_control_command_;
   rclcpp::Subscription<autoware_control_msgs::msg::GateMode>::SharedPtr sub_current_gate_mode_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_twist_;
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_is_state_timeout_;
+  rclcpp::Subscription<autoware_system_msgs::msg::TimeoutNotification>::SharedPtr sub_is_state_timeout_;
 
   autoware_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_;
   autoware_system_msgs::msg::DrivingCapability::ConstSharedPtr driving_capability_;
   autoware_control_msgs::msg::ControlCommand::ConstSharedPtr prev_control_command_;
   autoware_control_msgs::msg::GateMode::ConstSharedPtr current_gate_mode_;
   geometry_msgs::msg::TwistStamped::ConstSharedPtr twist_;
-  std_msgs::msg::Bool::ConstSharedPtr is_state_timeout_;
+  autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr is_state_timeout_;
 
   void onAutowareState(const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg);
   void onDrivingCapability(const autoware_system_msgs::msg::DrivingCapability::ConstSharedPtr msg);
@@ -69,7 +69,8 @@ private:
   void onPrevControlCommand(const autoware_vehicle_msgs::msg::VehicleCommand::ConstSharedPtr msg);
   void onCurrentGateMode(const autoware_control_msgs::msg::GateMode::ConstSharedPtr msg);
   void onTwist(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
-  void onIsStateTimeout(const std_msgs::msg::Bool::ConstSharedPtr msg);
+  void onIsStateTimeout(
+    const autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr msg);
 
   // Service
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr srv_clear_emergency_;
@@ -110,7 +111,8 @@ private:
   rclcpp::Time initialized_time_;
   std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::DrivingCapability>>
   heartbeat_driving_capability_;
-  std::shared_ptr<HeaderlessHeartbeatChecker<std_msgs::msg::Bool>> heartbeat_is_state_timeout_;
+  std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::TimeoutNotification>>
+    heartbeat_is_state_timeout_;
 
   // Algorithm
   bool is_emergency_ = false;

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -106,7 +106,8 @@ EmergencyHandler::EmergencyHandler()
   heartbeat_driving_capability_ =
     std::make_shared<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::DrivingCapability>>(
     *this, "input/driving_capability", timeout_driving_capability_);
-  heartbeat_is_state_timeout_ = std::make_shared<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::TimeoutNotification>>(
+  heartbeat_is_state_timeout_ =
+    std::make_shared<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::TimeoutNotification>>(
     *this, "input/is_state_timeout", timeout_is_state_timeout_);
 
   // Service
@@ -199,7 +200,8 @@ bool EmergencyHandler::onClearEmergencyService(
   return true;
 }
 
-void EmergencyHandler::onIsStateTimeout(const autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr msg)
+void EmergencyHandler::onIsStateTimeout(
+  const autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr msg)
 {
   is_state_timeout_ = msg;
 }

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -18,6 +18,7 @@
 
 #include "emergency_handler/emergency_handler_core.hpp"
 
+
 namespace
 {
 diagnostic_msgs::msg::DiagnosticStatus createDiagnosticStatus(
@@ -97,7 +98,7 @@ EmergencyHandler::EmergencyHandler()
   sub_twist_ = create_subscription<geometry_msgs::msg::TwistStamped>(
     "input/twist", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onTwist, this, _1));
-  sub_is_state_timeout_ = create_subscription<std_msgs::msg::Bool>(
+  sub_is_state_timeout_ = create_subscription<autoware_system_msgs::msg::TimeoutNotification>(
     "input/is_state_timeout", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onIsStateTimeout, this, _1));
 
@@ -105,7 +106,7 @@ EmergencyHandler::EmergencyHandler()
   heartbeat_driving_capability_ =
     std::make_shared<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::DrivingCapability>>(
     *this, "input/driving_capability", timeout_driving_capability_);
-  heartbeat_is_state_timeout_ = std::make_shared<HeaderlessHeartbeatChecker<std_msgs::msg::Bool>>(
+  heartbeat_is_state_timeout_ = std::make_shared<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::TimeoutNotification>>(
     *this, "input/is_state_timeout", timeout_is_state_timeout_);
 
   // Service
@@ -198,7 +199,7 @@ bool EmergencyHandler::onClearEmergencyService(
   return true;
 }
 
-void EmergencyHandler::onIsStateTimeout(const std_msgs::msg::Bool::ConstSharedPtr msg)
+void EmergencyHandler::onIsStateTimeout(const autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr msg)
 {
   is_state_timeout_ = msg;
 }


### PR DESCRIPTION
```ros2-foxy@ros2foxy:~$ ros2 node info /emergency_handler 
/emergency_handler
  Subscribers:
    /autoware/driving_capability: autoware_system_msgs/msg/DrivingCapability
    /autoware/state: autoware_system_msgs/msg/AutowareState
    /control/current_gate_mode: autoware_control_msgs/msg/GateMode
    /control/vehicle_cmd: autoware_vehicle_msgs/msg/VehicleCommand
    /localization/twist: geometry_msgs/msg/TwistStamped
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /state_timeout_checker/is_state_timeout: autoware_system_msgs/msg/TimeoutNotification
  Publishers:
    /diagnostics_err: diagnostic_msgs/msg/DiagnosticArray
    /parameter_e
   .
   .
.
```
