### PR TITLE
fix emergency handler

### DIFF
--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -356,10 +356,10 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
     using autoware_system_msgs::msg::HazardStatus;
 
     const auto is_in_auto_ignore_state =
-      (autoware_state_->state != AutowareState::INITIALIZING_VEHICLE) &&
-      (autoware_state_->state != AutowareState::WAITING_FOR_ROUTE) &&
-      (autoware_state_->state != AutowareState::PLANNING) &&
-      (autoware_state_->state != AutowareState::FINALIZING);
+      (autoware_state_->state == AutowareState::INITIALIZING_VEHICLE) ||
+      (autoware_state_->state == AutowareState::WAITING_FOR_ROUTE) ||
+      (autoware_state_->state == AutowareState::PLANNING) ||
+      (autoware_state_->state == AutowareState::FINALIZING);
 
     if (current_gate_mode_->data == GateMode::AUTO && is_in_auto_ignore_state) {
       hazard_status.level = HazardStatus::NO_FAULT;


### PR DESCRIPTION
Fixed implement miss

Original(correct): Autoware_state does not transition to emergency state when current state is  INITIALIZING_VEHICLE, WAITING_FOR_ROUTE, etc.

Missing implementation:  Autoware_state can transition to emergency state only when current state is  INITIALIZING_VEHICLE, WAITING_FOR_ROUTE, etc.