### PR TITLE
add timeout notification stamp msgs

### DIFF
--- a/common/msgs/autoware_system_msgs/CMakeLists.txt
+++ b/common/msgs/autoware_system_msgs/CMakeLists.txt
@@ -19,6 +19,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/DrivingCapability.msg"
   "msg/HazardStatus.msg"
   "msg/HazardStatusStamped.msg"
+  "msg/TimeoutNotification.msg"
+  "msg/TimeoutNotificationStamped.msg"
   DEPENDENCIES diagnostic_msgs std_msgs
 )
 

--- a/common/msgs/autoware_system_msgs/CMakeLists.txt
+++ b/common/msgs/autoware_system_msgs/CMakeLists.txt
@@ -20,7 +20,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/HazardStatus.msg"
   "msg/HazardStatusStamped.msg"
   "msg/TimeoutNotification.msg"
-  "msg/TimeoutNotificationStamped.msg"
   DEPENDENCIES diagnostic_msgs std_msgs
 )
 

--- a/common/msgs/autoware_system_msgs/CMakeLists.txt
+++ b/common/msgs/autoware_system_msgs/CMakeLists.txt
@@ -20,6 +20,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/HazardStatus.msg"
   "msg/HazardStatusStamped.msg"
   "msg/TimeoutNotification.msg"
+  "msg/TimeoutNotificationStamped.msg"
   DEPENDENCIES diagnostic_msgs std_msgs
 )
 

--- a/common/msgs/autoware_system_msgs/msg/TimeoutNotification.msg
+++ b/common/msgs/autoware_system_msgs/msg/TimeoutNotification.msg
@@ -1,0 +1,1 @@
+bool data

--- a/common/msgs/autoware_system_msgs/msg/TimeoutNotification.msg
+++ b/common/msgs/autoware_system_msgs/msg/TimeoutNotification.msg
@@ -1,1 +1,2 @@
-bool data
+builtin_interfaces/Time stamp
+bool is_timeout

--- a/common/msgs/autoware_system_msgs/msg/TimeoutNotificationStamped.msg
+++ b/common/msgs/autoware_system_msgs/msg/TimeoutNotificationStamped.msg
@@ -1,2 +1,0 @@
-builtin_interfaces/Time stamp
-autoware_system_msgs/TimeoutNotification timeout_notification

--- a/common/msgs/autoware_system_msgs/msg/TimeoutNotificationStamped.msg
+++ b/common/msgs/autoware_system_msgs/msg/TimeoutNotificationStamped.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+autoware_system_msgs/TimeoutNotification timeout_notification

--- a/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
+++ b/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
@@ -26,7 +26,7 @@
 #include "autoware_system_msgs/msg/autoware_state.hpp"
 #include "autoware_system_msgs/msg/driving_capability.hpp"
 #include "autoware_system_msgs/msg/hazard_status_stamped.hpp"
-#include "autoware_system_msgs/msg/timeout_notification_stamped.hpp"
+#include "autoware_system_msgs/msg/timeout_notification.hpp"
 #include "autoware_vehicle_msgs/msg/shift_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
 #include "autoware_vehicle_msgs/msg/vehicle_command.hpp"
@@ -54,7 +54,7 @@ private:
     sub_prev_control_command_;
   rclcpp::Subscription<autoware_control_msgs::msg::GateMode>::SharedPtr sub_current_gate_mode_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_twist_;
-  rclcpp::Subscription<autoware_system_msgs::msg::TimeoutNotificationStamped>::SharedPtr
+  rclcpp::Subscription<autoware_system_msgs::msg::TimeoutNotification>::SharedPtr
     sub_is_state_timeout_;
 
   autoware_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_;
@@ -62,7 +62,7 @@ private:
   autoware_control_msgs::msg::ControlCommand::ConstSharedPtr prev_control_command_;
   autoware_control_msgs::msg::GateMode::ConstSharedPtr current_gate_mode_;
   geometry_msgs::msg::TwistStamped::ConstSharedPtr twist_;
-  autoware_system_msgs::msg::TimeoutNotificationStamped::ConstSharedPtr is_state_timeout_;
+  autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr is_state_timeout_;
 
   void onAutowareState(const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg);
   void onDrivingCapability(const autoware_system_msgs::msg::DrivingCapability::ConstSharedPtr msg);
@@ -71,7 +71,7 @@ private:
   void onCurrentGateMode(const autoware_control_msgs::msg::GateMode::ConstSharedPtr msg);
   void onTwist(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
   void onIsStateTimeout(
-    const autoware_system_msgs::msg::TimeoutNotificationStamped::ConstSharedPtr msg);
+    const autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr msg);
 
   // Service
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr srv_clear_emergency_;
@@ -112,7 +112,7 @@ private:
   rclcpp::Time initialized_time_;
   std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::DrivingCapability>>
   heartbeat_driving_capability_;
-  std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::TimeoutNotificationStamped>>
+  std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::TimeoutNotification>>
   heartbeat_is_state_timeout_;
 
   // Algorithm

--- a/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
+++ b/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
@@ -26,6 +26,7 @@
 #include "autoware_system_msgs/msg/autoware_state.hpp"
 #include "autoware_system_msgs/msg/driving_capability.hpp"
 #include "autoware_system_msgs/msg/hazard_status_stamped.hpp"
+#include "autoware_system_msgs/msg/timeout_notification_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/shift_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
 #include "autoware_vehicle_msgs/msg/vehicle_command.hpp"
@@ -33,7 +34,6 @@
 // ROS2 core
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "std_msgs/msg/bool.hpp"
 #include "std_srvs/srv/trigger.hpp"
 #include "rclcpp/create_timer.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -54,14 +54,15 @@ private:
     sub_prev_control_command_;
   rclcpp::Subscription<autoware_control_msgs::msg::GateMode>::SharedPtr sub_current_gate_mode_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_twist_;
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_is_state_timeout_;
+  rclcpp::Subscription<autoware_system_msgs::msg::TimeoutNotificationStamped>::SharedPtr
+    sub_is_state_timeout_;
 
   autoware_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_;
   autoware_system_msgs::msg::DrivingCapability::ConstSharedPtr driving_capability_;
   autoware_control_msgs::msg::ControlCommand::ConstSharedPtr prev_control_command_;
   autoware_control_msgs::msg::GateMode::ConstSharedPtr current_gate_mode_;
   geometry_msgs::msg::TwistStamped::ConstSharedPtr twist_;
-  std_msgs::msg::Bool::ConstSharedPtr is_state_timeout_;
+  autoware_system_msgs::msg::TimeoutNotificationStamped::ConstSharedPtr is_state_timeout_;
 
   void onAutowareState(const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg);
   void onDrivingCapability(const autoware_system_msgs::msg::DrivingCapability::ConstSharedPtr msg);
@@ -69,7 +70,8 @@ private:
   void onPrevControlCommand(const autoware_vehicle_msgs::msg::VehicleCommand::ConstSharedPtr msg);
   void onCurrentGateMode(const autoware_control_msgs::msg::GateMode::ConstSharedPtr msg);
   void onTwist(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
-  void onIsStateTimeout(const std_msgs::msg::Bool::ConstSharedPtr msg);
+  void onIsStateTimeout(
+    const autoware_system_msgs::msg::TimeoutNotificationStamped::ConstSharedPtr msg);
 
   // Service
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr srv_clear_emergency_;
@@ -110,7 +112,8 @@ private:
   rclcpp::Time initialized_time_;
   std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::DrivingCapability>>
   heartbeat_driving_capability_;
-  std::shared_ptr<HeaderlessHeartbeatChecker<std_msgs::msg::Bool>> heartbeat_is_state_timeout_;
+  std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::TimeoutNotificationStamped>>
+  heartbeat_is_state_timeout_;
 
   // Algorithm
   bool is_emergency_ = false;

--- a/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
+++ b/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
@@ -26,7 +26,7 @@
 #include "autoware_system_msgs/msg/autoware_state.hpp"
 #include "autoware_system_msgs/msg/driving_capability.hpp"
 #include "autoware_system_msgs/msg/hazard_status_stamped.hpp"
-#include "autoware_system_msgs/msg/timeout_notification.hpp"
+#include "autoware_system_msgs/msg/timeout_notification_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/shift_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
 #include "autoware_vehicle_msgs/msg/vehicle_command.hpp"
@@ -54,7 +54,7 @@ private:
     sub_prev_control_command_;
   rclcpp::Subscription<autoware_control_msgs::msg::GateMode>::SharedPtr sub_current_gate_mode_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_twist_;
-  rclcpp::Subscription<autoware_system_msgs::msg::TimeoutNotification>::SharedPtr
+  rclcpp::Subscription<autoware_system_msgs::msg::TimeoutNotificationStamped>::SharedPtr
     sub_is_state_timeout_;
 
   autoware_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_;
@@ -62,7 +62,7 @@ private:
   autoware_control_msgs::msg::ControlCommand::ConstSharedPtr prev_control_command_;
   autoware_control_msgs::msg::GateMode::ConstSharedPtr current_gate_mode_;
   geometry_msgs::msg::TwistStamped::ConstSharedPtr twist_;
-  autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr is_state_timeout_;
+  autoware_system_msgs::msg::TimeoutNotificationStamped::ConstSharedPtr is_state_timeout_;
 
   void onAutowareState(const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg);
   void onDrivingCapability(const autoware_system_msgs::msg::DrivingCapability::ConstSharedPtr msg);
@@ -71,7 +71,7 @@ private:
   void onCurrentGateMode(const autoware_control_msgs::msg::GateMode::ConstSharedPtr msg);
   void onTwist(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
   void onIsStateTimeout(
-    const autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr msg);
+    const autoware_system_msgs::msg::TimeoutNotificationStamped::ConstSharedPtr msg);
 
   // Service
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr srv_clear_emergency_;
@@ -112,7 +112,7 @@ private:
   rclcpp::Time initialized_time_;
   std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::DrivingCapability>>
   heartbeat_driving_capability_;
-  std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::TimeoutNotification>>
+  std::shared_ptr<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::TimeoutNotificationStamped>>
   heartbeat_is_state_timeout_;
 
   // Algorithm

--- a/system/emergency_handler/include/emergency_handler/state_timeout_checker_core.hpp
+++ b/system/emergency_handler/include/emergency_handler/state_timeout_checker_core.hpp
@@ -20,7 +20,7 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "autoware_system_msgs/msg/autoware_state.hpp"
-#include "autoware_system_msgs/msg/timeout_notification.hpp"
+#include "autoware_system_msgs/msg/timeout_notification_stamped.hpp"
 
 struct TimeoutThreshold
 {
@@ -50,7 +50,7 @@ private:
   void onAutowareState(const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg);
 
   // Publisher
-  rclcpp::Publisher<autoware_system_msgs::msg::TimeoutNotification>::SharedPtr
+  rclcpp::Publisher<autoware_system_msgs::msg::TimeoutNotificationStamped>::SharedPtr
     pub_is_state_timeout_;
 
   // Timer

--- a/system/emergency_handler/include/emergency_handler/state_timeout_checker_core.hpp
+++ b/system/emergency_handler/include/emergency_handler/state_timeout_checker_core.hpp
@@ -20,7 +20,7 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "autoware_system_msgs/msg/autoware_state.hpp"
-#include "std_msgs/msg/bool.hpp"
+#include "autoware_system_msgs/msg/timeout_notification_stamped.hpp"
 
 struct TimeoutThreshold
 {
@@ -50,7 +50,7 @@ private:
   void onAutowareState(const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg);
 
   // Publisher
-  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr
+  rclcpp::Publisher<autoware_system_msgs::msg::TimeoutNotificationStamped>::SharedPtr
     pub_is_state_timeout_;
 
   // Timer

--- a/system/emergency_handler/include/emergency_handler/state_timeout_checker_core.hpp
+++ b/system/emergency_handler/include/emergency_handler/state_timeout_checker_core.hpp
@@ -20,7 +20,7 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "autoware_system_msgs/msg/autoware_state.hpp"
-#include "autoware_system_msgs/msg/timeout_notification_stamped.hpp"
+#include "autoware_system_msgs/msg/timeout_notification.hpp"
 
 struct TimeoutThreshold
 {
@@ -50,7 +50,7 @@ private:
   void onAutowareState(const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg);
 
   // Publisher
-  rclcpp::Publisher<autoware_system_msgs::msg::TimeoutNotificationStamped>::SharedPtr
+  rclcpp::Publisher<autoware_system_msgs::msg::TimeoutNotification>::SharedPtr
     pub_is_state_timeout_;
 
   // Timer

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -109,8 +109,9 @@ EmergencyHandler::EmergencyHandler()
     *this, "input/driving_capability", timeout_driving_capability_);
   heartbeat_is_state_timeout_ =
     std::make_shared<HeaderlessHeartbeatChecker
-      <autoware_system_msgs::msg::TimeoutNotificationStamped>>
-      (*this, "input/is_state_timeout", timeout_is_state_timeout_);
+      <autoware_system_msgs::msg::TimeoutNotificationStamped>>(
+    *this, "input/is_state_timeout",
+    timeout_is_state_timeout_);
 
   // Service
   srv_clear_emergency_ = this->create_service<std_srvs::srv::Trigger>(

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -99,7 +99,7 @@ EmergencyHandler::EmergencyHandler()
     "input/twist", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onTwist, this, _1));
   sub_is_state_timeout_ =
-    create_subscription<autoware_system_msgs::msg::TimeoutNotificationStamped>(
+    create_subscription<autoware_system_msgs::msg::TimeoutNotification>(
     "input/is_state_timeout", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onIsStateTimeout, this, _1));
 
@@ -109,7 +109,7 @@ EmergencyHandler::EmergencyHandler()
     *this, "input/driving_capability", timeout_driving_capability_);
   heartbeat_is_state_timeout_ =
     std::make_shared<HeaderlessHeartbeatChecker
-      <autoware_system_msgs::msg::TimeoutNotificationStamped>>(
+      <autoware_system_msgs::msg::TimeoutNotification>>(
     *this, "input/is_state_timeout",
     timeout_is_state_timeout_);
 
@@ -204,7 +204,7 @@ bool EmergencyHandler::onClearEmergencyService(
 }
 
 void EmergencyHandler::onIsStateTimeout(
-  const autoware_system_msgs::msg::TimeoutNotificationStamped::ConstSharedPtr msg)
+  const autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr msg)
 {
   is_state_timeout_ = msg;
 }
@@ -281,7 +281,7 @@ bool EmergencyHandler::isDataReady()
     return false;
   }
 
-  if (!(is_state_timeout_->timeout_notification.data)) {
+  if (!(is_state_timeout_->is_timeout)) {
     RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), std::chrono::milliseconds(5000).count(),
       "waiting for is_state_timeout msg...");
@@ -407,7 +407,7 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
           "heartbeat_is_state_timeout is timeout"));
     }
 
-    if (is_state_timeout_->timeout_notification.data) {
+    if (is_state_timeout_->is_timeout) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "state is timeout");

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -99,7 +99,7 @@ EmergencyHandler::EmergencyHandler()
     "input/twist", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onTwist, this, _1));
   sub_is_state_timeout_ =
-    create_subscription<autoware_system_msgs::msg::TimeoutNotificationStamped>(
+    create_subscription<autoware_system_msgs::msg::TimeoutNotification>(
     "input/is_state_timeout", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onIsStateTimeout, this, _1));
 
@@ -109,7 +109,7 @@ EmergencyHandler::EmergencyHandler()
     *this, "input/driving_capability", timeout_driving_capability_);
   heartbeat_is_state_timeout_ =
     std::make_shared<HeaderlessHeartbeatChecker
-      <autoware_system_msgs::msg::TimeoutNotificationStamped>>(
+      <autoware_system_msgs::msg::TimeoutNotification>>(
     *this, "input/is_state_timeout",
     timeout_is_state_timeout_);
 
@@ -204,7 +204,7 @@ bool EmergencyHandler::onClearEmergencyService(
 }
 
 void EmergencyHandler::onIsStateTimeout(
-  const autoware_system_msgs::msg::TimeoutNotificationStamped::ConstSharedPtr msg)
+  const autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr msg)
 {
   is_state_timeout_ = msg;
 }
@@ -281,7 +281,7 @@ bool EmergencyHandler::isDataReady()
     return false;
   }
 
-  if (!(is_state_timeout_->timeout_notification.data)) {
+  if (!(is_state_timeout_->data)) {
     RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), std::chrono::milliseconds(5000).count(),
       "waiting for is_state_timeout msg...");
@@ -407,7 +407,7 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
           "heartbeat_is_state_timeout is timeout"));
     }
 
-    if (is_state_timeout_->timeout_notification.data) {
+    if (is_state_timeout_->data) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "state is timeout");

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -99,7 +99,7 @@ EmergencyHandler::EmergencyHandler()
     "input/twist", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onTwist, this, _1));
   sub_is_state_timeout_ =
-    create_subscription<autoware_system_msgs::msg::TimeoutNotification>(
+    create_subscription<autoware_system_msgs::msg::TimeoutNotificationStamped>(
     "input/is_state_timeout", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onIsStateTimeout, this, _1));
 
@@ -109,7 +109,7 @@ EmergencyHandler::EmergencyHandler()
     *this, "input/driving_capability", timeout_driving_capability_);
   heartbeat_is_state_timeout_ =
     std::make_shared<HeaderlessHeartbeatChecker
-      <autoware_system_msgs::msg::TimeoutNotification>>(
+      <autoware_system_msgs::msg::TimeoutNotificationStamped>>(
     *this, "input/is_state_timeout",
     timeout_is_state_timeout_);
 
@@ -204,7 +204,7 @@ bool EmergencyHandler::onClearEmergencyService(
 }
 
 void EmergencyHandler::onIsStateTimeout(
-  const autoware_system_msgs::msg::TimeoutNotification::ConstSharedPtr msg)
+  const autoware_system_msgs::msg::TimeoutNotificationStamped::ConstSharedPtr msg)
 {
   is_state_timeout_ = msg;
 }
@@ -281,7 +281,7 @@ bool EmergencyHandler::isDataReady()
     return false;
   }
 
-  if (!(is_state_timeout_->data)) {
+  if (!(is_state_timeout_->timeout_notification.data)) {
     RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), std::chrono::milliseconds(5000).count(),
       "waiting for is_state_timeout msg...");
@@ -407,7 +407,7 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
           "heartbeat_is_state_timeout is timeout"));
     }
 
-    if (is_state_timeout_->data) {
+    if (is_state_timeout_->timeout_notification.data) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "state is timeout");

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -18,6 +18,7 @@
 
 #include "emergency_handler/emergency_handler_core.hpp"
 
+
 namespace
 {
 diagnostic_msgs::msg::DiagnosticStatus createDiagnosticStatus(
@@ -97,7 +98,8 @@ EmergencyHandler::EmergencyHandler()
   sub_twist_ = create_subscription<geometry_msgs::msg::TwistStamped>(
     "input/twist", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onTwist, this, _1));
-  sub_is_state_timeout_ = create_subscription<std_msgs::msg::Bool>(
+  sub_is_state_timeout_ =
+    create_subscription<autoware_system_msgs::msg::TimeoutNotificationStamped>(
     "input/is_state_timeout", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onIsStateTimeout, this, _1));
 
@@ -105,8 +107,10 @@ EmergencyHandler::EmergencyHandler()
   heartbeat_driving_capability_ =
     std::make_shared<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::DrivingCapability>>(
     *this, "input/driving_capability", timeout_driving_capability_);
-  heartbeat_is_state_timeout_ = std::make_shared<HeaderlessHeartbeatChecker<std_msgs::msg::Bool>>(
-    *this, "input/is_state_timeout", timeout_is_state_timeout_);
+  heartbeat_is_state_timeout_ =
+    std::make_shared<HeaderlessHeartbeatChecker
+      <autoware_system_msgs::msg::TimeoutNotificationStamped>>
+      (*this, "input/is_state_timeout", timeout_is_state_timeout_);
 
   // Service
   srv_clear_emergency_ = this->create_service<std_srvs::srv::Trigger>(
@@ -198,7 +202,8 @@ bool EmergencyHandler::onClearEmergencyService(
   return true;
 }
 
-void EmergencyHandler::onIsStateTimeout(const std_msgs::msg::Bool::ConstSharedPtr msg)
+void EmergencyHandler::onIsStateTimeout(
+  const autoware_system_msgs::msg::TimeoutNotificationStamped::ConstSharedPtr msg)
 {
   is_state_timeout_ = msg;
 }
@@ -275,7 +280,7 @@ bool EmergencyHandler::isDataReady()
     return false;
   }
 
-  if (!is_state_timeout_) {
+  if (!(is_state_timeout_->timeout_notification.data)) {
     RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), std::chrono::milliseconds(5000).count(),
       "waiting for is_state_timeout msg...");
@@ -401,7 +406,7 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
           "heartbeat_is_state_timeout is timeout"));
     }
 
-    if (is_state_timeout_->data) {
+    if (is_state_timeout_->timeout_notification.data) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "state is timeout");

--- a/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
+++ b/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
@@ -34,7 +34,7 @@ StateTimeoutChecker::StateTimeoutChecker()
 
   // Publisher
   pub_is_state_timeout_ =
-    create_publisher<autoware_system_msgs::msg::TimeoutNotification>(
+    create_publisher<autoware_system_msgs::msg::TimeoutNotificationStamped>(
     "output/is_state_timeout", rclcpp::QoS{1});
 
   // Timer
@@ -78,8 +78,9 @@ void StateTimeoutChecker::onTimer()
   }
 
   // Check timeout
-  autoware_system_msgs::msg::TimeoutNotification is_state_timeout;
-  is_state_timeout.data = isStateTimeout();
+  autoware_system_msgs::msg::TimeoutNotificationStamped is_state_timeout;
+  is_state_timeout.timeout_notification.data = isStateTimeout();
+  is_state_timeout.stamp = this->now();
   pub_is_state_timeout_->publish(is_state_timeout);
 }
 

--- a/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
+++ b/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
@@ -34,7 +34,7 @@ StateTimeoutChecker::StateTimeoutChecker()
 
   // Publisher
   pub_is_state_timeout_ =
-    create_publisher<autoware_system_msgs::msg::TimeoutNotificationStamped>(
+    create_publisher<autoware_system_msgs::msg::TimeoutNotification>(
     "output/is_state_timeout", rclcpp::QoS{1});
 
   // Timer
@@ -78,8 +78,8 @@ void StateTimeoutChecker::onTimer()
   }
 
   // Check timeout
-  autoware_system_msgs::msg::TimeoutNotificationStamped is_state_timeout;
-  is_state_timeout.timeout_notification.data = isStateTimeout();
+  autoware_system_msgs::msg::TimeoutNotification is_state_timeout;
+  is_state_timeout.is_timeout = isStateTimeout();
   is_state_timeout.stamp = this->now();
   pub_is_state_timeout_->publish(is_state_timeout);
 }

--- a/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
+++ b/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
@@ -34,7 +34,8 @@ StateTimeoutChecker::StateTimeoutChecker()
 
   // Publisher
   pub_is_state_timeout_ =
-    create_publisher<std_msgs::msg::Bool>("output/is_state_timeout", rclcpp::QoS{1});
+    create_publisher<autoware_system_msgs::msg::TimeoutNotificationStamped>(
+    "output/is_state_timeout", rclcpp::QoS{1});
 
   // Timer
   auto timer_callback = std::bind(&StateTimeoutChecker::onTimer, this);
@@ -77,8 +78,9 @@ void StateTimeoutChecker::onTimer()
   }
 
   // Check timeout
-  std_msgs::msg::Bool is_state_timeout;
-  is_state_timeout.data = isStateTimeout();
+  autoware_system_msgs::msg::TimeoutNotificationStamped is_state_timeout;
+  is_state_timeout.timeout_notification.data = isStateTimeout();
+  is_state_timeout.stamp = this->now();
   pub_is_state_timeout_->publish(is_state_timeout);
 }
 

--- a/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
+++ b/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
@@ -34,7 +34,7 @@ StateTimeoutChecker::StateTimeoutChecker()
 
   // Publisher
   pub_is_state_timeout_ =
-    create_publisher<autoware_system_msgs::msg::TimeoutNotificationStamped>(
+    create_publisher<autoware_system_msgs::msg::TimeoutNotification>(
     "output/is_state_timeout", rclcpp::QoS{1});
 
   // Timer
@@ -78,9 +78,8 @@ void StateTimeoutChecker::onTimer()
   }
 
   // Check timeout
-  autoware_system_msgs::msg::TimeoutNotificationStamped is_state_timeout;
-  is_state_timeout.timeout_notification.data = isStateTimeout();
-  is_state_timeout.stamp = this->now();
+  autoware_system_msgs::msg::TimeoutNotification is_state_timeout;
+  is_state_timeout.data = isStateTimeout();
   pub_is_state_timeout_->publish(is_state_timeout);
 }
 


### PR DESCRIPTION
rm std_msgs

```
ros2 node info /emergency_handler
/emergency_handler
  Subscribers:
    /autoware/driving_capability: autoware_system_msgs/msg/DrivingCapability
    /autoware/state: autoware_system_msgs/msg/AutowareState
    /control/current_gate_mode: autoware_control_msgs/msg/GateMode
    /control/vehicle_cmd: autoware_vehicle_msgs/msg/VehicleCommand
    /is_state_timeout: autoware_system_msgs/msg/TimeoutNotificationStamped
    /localization/twist: geometry_msgs/msg/TwistStamped
    /parameter_events: rcl_interfaces/msg/ParameterEvent
  Publishers:
    /diagnostics_err: diagnostic_msgs/msg/DiagnosticArray
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /rosout: rcl_interfaces/msg/Log
    /system/emergency/control_cmd: autoware_control_msgs/msg/ControlCommandStamped
    /system/emergency/hazard_status: autoware_system_msgs/msg/HazardStatusStamped
    /system/emergency/is_emergency: autoware_control_msgs/msg/EmergencyMode
    /system/emergency/shift_cmd: autoware_vehicle_msgs/msg/ShiftStamped
    /system/emergency/turn_signal_cmd: autoware_vehicle_msgs/msg/TurnSignal
  Service Servers:
    /emergency_handler/describe_parameters: rcl_interfaces/srv/DescribeParameters
    /emergency_handler/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
    /emergency_handler/get_parameters: rcl_interfaces/srv/GetParameters
    /emergency_handler/list_parameters: rcl_interfaces/srv/ListParameters
    /emergency_handler/set_parameters: rcl_interfaces/srv/SetParameters
    /emergency_handler/set_parameters_atomically: rcl_interfaces/srv/SetParamete
```