### PR TITLE
add nullptr check when publish concatenate data

### DIFF
--- a/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
+++ b/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
@@ -266,7 +266,9 @@ void PointCloudConcatenateDataSynchronizerComponent::publish()
         "(not_subscribed_topic_name size = )" << not_subscribed_topic_name.size());
   }
 
-  pub_output_->publish(*concat_cloud_ptr_);
+  if (concat_cloud_ptr_) {
+    pub_output_->publish(*concat_cloud_ptr_);
+  }
 
   std_msgs::msg::Int32 concat_num_msg;
   concat_num_msg.data = concat_num;


### PR DESCRIPTION
I fixed concatenate_data bug.

I've got this error when input nullptr as a publish message at here https://github.com/tier4/AutowareArchitectureProposal.iv/blob/9a32729ef7d3d8bdbd9ab4189184aab58d78d093/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp#L269

```
[component_container-3] terminate called after throwing an instance of 'rclcpp::exceptions::RCLInvalidArgument'
[component_container-3]   what():  failed to publish message: ros_message argument is null, at /tmp/binarydeb/ros-foxy-rcl-1.1.10/src/rcl/publisher.c:317`
```