### PR TITLE
fix max velocity visualization

### DIFF
--- a/common/util/rviz_plugins/autoware_planning_rviz_plugin/src/tools/max_velocity.cpp
+++ b/common/util/rviz_plugins/autoware_planning_rviz_plugin/src/tools/max_velocity.cpp
@@ -105,7 +105,8 @@ void MaxVelocityDisplay::subscribe()
   if (topic_name.length() > 0 && topic_name != "/") {
     rclcpp::Node::SharedPtr raw_node = context_->getRosNodeAbstraction().lock()->get_raw_node();
     max_vel_sub_ = raw_node->create_subscription<autoware_planning_msgs::msg::VelocityLimit>(
-      topic_name, rclcpp::QoS{1}.transient_local(), std::bind(&MaxVelocityDisplay::processMessage, this, std::placeholders::_1));
+      topic_name, rclcpp::QoS{1}.transient_local(),
+      std::bind(&MaxVelocityDisplay::processMessage, this, std::placeholders::_1));
   }
 }
 

--- a/common/util/rviz_plugins/autoware_planning_rviz_plugin/src/tools/max_velocity.cpp
+++ b/common/util/rviz_plugins/autoware_planning_rviz_plugin/src/tools/max_velocity.cpp
@@ -105,7 +105,7 @@ void MaxVelocityDisplay::subscribe()
   if (topic_name.length() > 0 && topic_name != "/") {
     rclcpp::Node::SharedPtr raw_node = context_->getRosNodeAbstraction().lock()->get_raw_node();
     max_vel_sub_ = raw_node->create_subscription<autoware_planning_msgs::msg::VelocityLimit>(
-      topic_name, 10, std::bind(&MaxVelocityDisplay::processMessage, this, std::placeholders::_1));
+      topic_name, rclcpp::QoS{1}.transient_local(), std::bind(&MaxVelocityDisplay::processMessage, this, std::placeholders::_1));
   }
 }
 

--- a/planning/scenario_planning/common/motion_velocity_optimizer/src/motion_velocity_optimizer.cpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/src/motion_velocity_optimizer.cpp
@@ -94,9 +94,6 @@ MotionVelocityOptimizer::MotionVelocityOptimizer()
   pub_velocity_limit_ =
     create_publisher<autoware_planning_msgs::msg::VelocityLimit>(
     "output/current_velocity_limit_mps", durable_qos);
-  // publish default max velocity
-  pub_velocity_limit_->publish(createVelocityLimitMsg(p.max_velocity));
-
   pub_dist_to_stopline_ = create_publisher<autoware_debug_msgs::msg::Float32Stamped>(
     "distance_to_stopline", rclcpp::QoS{1});
   pub_over_stop_velocity_ = create_publisher<autoware_planning_msgs::msg::StopSpeedExceeded>(
@@ -168,6 +165,9 @@ MotionVelocityOptimizer::MotionVelocityOptimizer()
 
   /* wait to get vehicle position */
   blockUntilVehiclePositionAvailable(tf2::durationFromSec(1.0));
+
+  // publish default max velocity
+  pub_velocity_limit_->publish(createVelocityLimitMsg(p.max_velocity));
 }
 MotionVelocityOptimizer::~MotionVelocityOptimizer() {}
 


### PR DESCRIPTION
Fix the bug that the max velocityis not visualized in rviz.

![image](https://user-images.githubusercontent.com/59680180/109636321-c6741180-7b8e-11eb-8320-7d4917931a0e.png)
