### PR TITLE
[map_loader] modify colors for lane markers for better visualization

### DIFF
--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization.cpp
@@ -84,9 +84,9 @@ void binMapCallback(const autoware_lanelet2_msgs::msg::MapBin::SharedPtr msg)
   std_msgs::msg::ColorRGBA cl_road, cl_cross, cl_pedestrian_markings, cl_ll_borders, cl_stoplines,
     cl_trafficlights, cl_detection_areas, cl_parking_lots, cl_parking_spaces, cl_lanelet_id,
     cl_obstacle_polygons;
-  setColor(&cl_road, 0.27, 0.27, 0.27, 0.999);
-  setColor(&cl_cross, 0.27, 0.3, 0.27, 0.5);
-  setColor(&cl_pedestrian_markings, 0.5, 0.5, 0.5, 0.999);
+  setColor(&cl_road, 0.7, 0.7, 0.7, 0.2);
+  setColor(&cl_cross, 0.7, 1.0, 0.7, 0.2);
+  setColor(&cl_pedestrian_markings, 0.5, 0.5, 0.5, 0.8);
   setColor(&cl_ll_borders, 0.5, 0.5, 0.5, 0.999);
   setColor(&cl_stoplines, 0.5, 0.5, 0.5, 0.999);
   setColor(&cl_trafficlights, 0.5, 0.5, 0.5, 0.8);


### PR DESCRIPTION
This improves visualization of path/trajectory markers which is currently hidden by lanelet2 map visualization markers.

before: 
<img src="https://user-images.githubusercontent.com/43976834/109647392-96336f80-7b9c-11eb-9f5c-c3fedbca15da.png" width=400/>

after:
<img src=https://user-images.githubusercontent.com/43976834/109647549-c67b0e00-7b9c-11eb-8838-8271bc694b02.png width=400/>
