### PR TITLE
fix obstacle_stop_planner

### DIFF
--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/node.cpp
@@ -191,7 +191,7 @@ void ObstacleStopPlannerNode::pathCallback(
   autoware_planning_msgs::msg::Trajectory extended_trajectory;
   extendTrajectory(*input_msg, extend_distance_, extended_trajectory);
 
-  const autoware_planning_msgs::msg::Trajectory base_path = *input_msg;
+  const autoware_planning_msgs::msg::Trajectory base_path = extended_trajectory;
   autoware_planning_msgs::msg::Trajectory output_msg = *input_msg;
   diagnostic_msgs::msg::DiagnosticStatus stop_reason_diag;
 


### PR DESCRIPTION
Fix implement miss in obstacle_stop_planner.
https://github.com/tier4/AutowareArchitectureProposal.iv/blob/master/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/node.cpp#L193

(At the current code, the trajectory is not extended regardless of the value of stop_planner.extend_distance)