### PR TITLE
fix launch file of topic_state_montior

### DIFF
--- a/system/topic_state_monitor/launch/topic_state_monitor.launch.xml
+++ b/system/topic_state_monitor/launch/topic_state_monitor.launch.xml
@@ -1,9 +1,5 @@
 <launch>
-  <arg name="node_name_suffix" default="" doc="node name suffix" />
-
-  <arg name="node_name" default="$(anon topic_state_monitor)" if="$(eval &quot;'$(var node_name_suffix)' == ''&quot;)" />
-  <arg name="node_name" default="topic_state_monitor_$(var node_name_suffix)" unless="$(eval &quot;'$(var node_name_suffix)' == ''&quot;)" />
-
+  <arg name="node_name_suffix" doc="node name suffix" />
   <arg name="topic" doc="input topic name" />
   <arg name="topic_type" doc="input topic type" />
   <arg name="diag_name" doc="diag name" />
@@ -12,7 +8,7 @@
   <arg name="timeout" doc="timeout period[s]" />
   <arg name="window_size" default="10" doc="warn rate[Hz]" />
 
-  <node pkg="topic_state_monitor" exec="topic_state_monitor_node" name="$(var node_name)" output="screen">
+  <node pkg="topic_state_monitor" exec="topic_state_monitor_node" name="topic_state_monitor_$(var node_name_suffix)" output="screen">
     <param name="topic" value="$(var topic)" />
     <param name="topic_type" value="$(var topic_type)" />
     <param name="diag_name" value="$(var diag_name)" />


### PR DESCRIPTION
Fix launch file of topic_state_monitor
(Fix bug that all the node-names of topic_state_monitor are the same.)
("node_name_suffix" become a mandatory option in the process of fixing bugs

![image](https://user-images.githubusercontent.com/59680180/110308642-b7d0a300-8043-11eb-8c94-7bc915636906.png)
![image](https://user-images.githubusercontent.com/59680180/110308653-bb642a00-8043-11eb-81c6-4a67bbad09ca.png)
