### PR TITLE
fix param name

### DIFF
--- a/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
+++ b/system/emergency_handler/src/state_timeout_checker/state_timeout_checker_core.cpp
@@ -23,9 +23,9 @@ StateTimeoutChecker::StateTimeoutChecker()
 {
   using std::placeholders::_1;
 
-  th_timeout_.InitializingVehicle = declare_parameter<double>("timeout/InitializingVehicle", 60.0);
-  th_timeout_.WaitingForRoute = declare_parameter<double>("timeout/WaitingForRoute", 60.0);
-  th_timeout_.Planning = declare_parameter<double>("timeout/Planning", 60.0);
+  th_timeout_.InitializingVehicle = declare_parameter<double>("timeout.InitializingVehicle", 60.0);
+  th_timeout_.WaitingForRoute = declare_parameter<double>("timeout.WaitingForRoute", 60.0);
+  th_timeout_.Planning = declare_parameter<double>("timeout.Planning", 60.0);
 
   // Subscriber
   sub_autoware_state_ = create_subscription<autoware_system_msgs::msg::AutowareState>(


### PR DESCRIPTION
Fix parameter name of state_timeout_checker

# How to check
 $ros2 param get /system/state_timeout_checker timeout.InitializingVehicle
