### PR TITLE
add timeout_ignore_state to emergency_handler

### DIFF
--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -383,7 +383,7 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
     const auto is_in_heartbeat_timeout_ignore_state =
       (autoware_state_->state == AutowareState::INITIALIZING_VEHICLE);
 
-    if (heartbeat_driving_capability_->isTimeout() && !is_in_heartbeat_timeout_ignore_state) {
+    if (!is_in_heartbeat_timeout_ignore_state && heartbeat_driving_capability_->isTimeout()) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "heartbeat_driving_capability is timeout");
@@ -394,7 +394,7 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
           "heartbeat_driving_capability is timeout"));
     }
 
-    if (heartbeat_is_state_timeout_->isTimeout() && !is_in_heartbeat_timeout_ignore_state) {
+    if (!is_in_heartbeat_timeout_ignore_state && heartbeat_is_state_timeout_->isTimeout()) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "heartbeat_is_state_timeout is timeout");

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -18,7 +18,6 @@
 
 #include "emergency_handler/emergency_handler_core.hpp"
 
-
 namespace
 {
 diagnostic_msgs::msg::DiagnosticStatus createDiagnosticStatus(
@@ -35,8 +34,7 @@ diagnostic_msgs::msg::DiagnosticStatus createDiagnosticStatus(
 }
 
 diagnostic_msgs::msg::DiagnosticArray convertHazardStatusToDiagnosticArray(
-  rclcpp::Clock::SharedPtr clock,
-  const autoware_system_msgs::msg::HazardStatus & hazard_status)
+  rclcpp::Clock::SharedPtr clock, const autoware_system_msgs::msg::HazardStatus & hazard_status)
 {
   using diagnostic_msgs::msg::DiagnosticStatus;
 
@@ -96,10 +94,8 @@ EmergencyHandler::EmergencyHandler()
     "input/current_gate_mode", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onCurrentGateMode, this, _1));
   sub_twist_ = create_subscription<geometry_msgs::msg::TwistStamped>(
-    "input/twist", rclcpp::QoS{1},
-    std::bind(&EmergencyHandler::onTwist, this, _1));
-  sub_is_state_timeout_ =
-    create_subscription<autoware_system_msgs::msg::TimeoutNotification>(
+    "input/twist", rclcpp::QoS{1}, std::bind(&EmergencyHandler::onTwist, this, _1));
+  sub_is_state_timeout_ = create_subscription<autoware_system_msgs::msg::TimeoutNotification>(
     "input/is_state_timeout", rclcpp::QoS{1},
     std::bind(&EmergencyHandler::onIsStateTimeout, this, _1));
 
@@ -108,10 +104,8 @@ EmergencyHandler::EmergencyHandler()
     std::make_shared<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::DrivingCapability>>(
     *this, "input/driving_capability", timeout_driving_capability_);
   heartbeat_is_state_timeout_ =
-    std::make_shared<HeaderlessHeartbeatChecker
-      <autoware_system_msgs::msg::TimeoutNotification>>(
-    *this, "input/is_state_timeout",
-    timeout_is_state_timeout_);
+    std::make_shared<HeaderlessHeartbeatChecker<autoware_system_msgs::msg::TimeoutNotification>>(
+    *this, "input/is_state_timeout", timeout_is_state_timeout_);
 
   // Service
   srv_clear_emergency_ = this->create_service<std_srvs::srv::Trigger>(
@@ -382,10 +376,14 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
 
   // Check timeout
   {
+    using autoware_system_msgs::msg::AutowareState;
     using autoware_system_msgs::msg::HazardStatus;
     using diagnostic_msgs::msg::DiagnosticStatus;
 
-    if (heartbeat_driving_capability_->isTimeout()) {
+    const auto is_in_timeout_ignore_state =
+      (autoware_state_->state == AutowareState::INITIALIZING_VEHICLE);
+
+    if (heartbeat_driving_capability_->isTimeout() && !is_in_timeout_ignore_state) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "heartbeat_driving_capability is timeout");
@@ -396,7 +394,7 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
           "heartbeat_driving_capability is timeout"));
     }
 
-    if (heartbeat_is_state_timeout_->isTimeout()) {
+    if (heartbeat_is_state_timeout_->isTimeout() && !is_in_timeout_ignore_state) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "heartbeat_is_state_timeout is timeout");
@@ -407,15 +405,14 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
           "heartbeat_is_state_timeout is timeout"));
     }
 
-    if (is_state_timeout_->is_timeout) {
+    if (is_state_timeout_->is_timeout && !is_in_timeout_ignore_state) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "state is timeout");
       hazard_status.level = HazardStatus::SINGLE_POINT_FAULT;
       hazard_status.diagnostics_spf.push_back(
         createDiagnosticStatus(
-          DiagnosticStatus::ERROR, "emergency_handler/state_timeout",
-          "state is timeout"));
+          DiagnosticStatus::ERROR, "emergency_handler/state_timeout", "state is timeout"));
     }
   }
 

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -380,10 +380,10 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
     using autoware_system_msgs::msg::HazardStatus;
     using diagnostic_msgs::msg::DiagnosticStatus;
 
-    const auto is_in_timeout_ignore_state =
+    const auto is_in_heartbeat_timeout_ignore_state =
       (autoware_state_->state == AutowareState::INITIALIZING_VEHICLE);
 
-    if (heartbeat_driving_capability_->isTimeout() && !is_in_timeout_ignore_state) {
+    if (heartbeat_driving_capability_->isTimeout() && !is_in_heartbeat_timeout_ignore_state) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "heartbeat_driving_capability is timeout");
@@ -394,7 +394,7 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
           "heartbeat_driving_capability is timeout"));
     }
 
-    if (heartbeat_is_state_timeout_->isTimeout() && !is_in_timeout_ignore_state) {
+    if (heartbeat_is_state_timeout_->isTimeout() && !is_in_heartbeat_timeout_ignore_state) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "heartbeat_is_state_timeout is timeout");
@@ -405,7 +405,7 @@ autoware_system_msgs::msg::HazardStatus EmergencyHandler::judgeHazardStatus()
           "heartbeat_is_state_timeout is timeout"));
     }
 
-    if (is_state_timeout_->is_timeout && !is_in_timeout_ignore_state) {
+    if (is_state_timeout_->is_timeout) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
         "state is timeout");


### PR DESCRIPTION
Add timeout_ignore_state to emergency_handler.

## Modification
When _is_in_timeout_ignore_state_ is True (autoware/state is INITIALIZING_VEHICLE), _hazard_status.level_ does not become ERROR by timeout of topics such as driving_capability.
The reason for the above change is that frequencies of these topics become unstable soon after starting Autoware.

