### PR TITLE
change wait time for state transition

### DIFF
--- a/system/autoware_state_monitor/src/autoware_state_monitor_node/state_machine.cpp
+++ b/system/autoware_state_monitor/src/autoware_state_monitor_node/state_machine.cpp
@@ -262,7 +262,7 @@ AutowareState StateMachine::judgeAutowareState() const
           }
 
           // Wait after planning completed to avoid sync error
-          constexpr double wait_time_after_planning = 1.0;
+          constexpr double wait_time_after_planning = 3.0;
           const auto time_from_planning = state_input_.current_time - times_.planning_completed;
           if (time_from_planning.seconds() > wait_time_after_planning) {
             flags_.waiting_after_planning = false;


### PR DESCRIPTION
## Modification
Change wait time for autoware-state transition from Planning to WaitForEngage (1.0s->3.0s).

## Reason of modifucation
If _autoware-state_ transitions to WaitForEngage while the _topic_state_monitor_ node has NoReceived error yet, _autoware-state_ quickly becomes Emergency. So, set enough time for autoware-state to transition to WaitForEngage 


