### PR TITLE
Revert "Modify autoware_version not to use transient_local (workaroun…

### DIFF
--- a/system/autoware_version/src/autoware_version.cpp
+++ b/system/autoware_version/src/autoware_version.cpp
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 #include <cstdlib>
-#include <chrono>
 #include <memory>
 #include <string>
-#include <utility>
 #include "rclcpp/rclcpp.hpp"
 #include "autoware_system_msgs/msg/autoware_version.hpp"
 
@@ -42,23 +40,13 @@ public:
     }
     RCLCPP_INFO(get_logger(), "ROS_DISTRO=%s", message.ros_distro.c_str());
 
-    // TODO(isamu-takagi): use transient_local after rosbrigde supports it
     publisher_ = create_publisher<autoware_system_msgs::msg::AutowareVersion>(
-      "autoware_version", rclcpp::QoS{1});
-
-    auto callback = [this, message] {publisher_->publish(message);};
-    timer_ = std::make_shared<rclcpp::GenericTimer<decltype(callback)>>(
-      get_clock(),
-      std::chrono::seconds{1},
-      std::move(callback),
-      get_node_base_interface()->get_context()
-    );
-    get_node_timers_interface()->add_timer(timer_, nullptr);
+      "autoware_version", rclcpp::QoS{1}.transient_local());
+    publisher_->publish(message);
   }
 
 private:
   rclcpp::Publisher<autoware_system_msgs::msg::AutowareVersion>::SharedPtr publisher_;
-  rclcpp::TimerBase::SharedPtr timer_;
 };
 
 int main(int argc, char ** argv)


### PR DESCRIPTION

This reverts commit 80ecf534fb5b040d6d7e256ed19dcb840eb6873b because `/autoware_version` topic is no longer the target of the rosbridge.