### PR TITLE
Fix autoware_utils

### DIFF
--- a/common/util/autoware_utils/include/autoware_utils/ros/self_pose_listener.hpp
+++ b/common/util/autoware_utils/include/autoware_utils/ros/self_pose_listener.hpp
@@ -15,6 +15,8 @@
 #ifndef AUTOWARE_UTILS__ROS__SELF_POSE_LISTENER_HPP_
 #define AUTOWARE_UTILS__ROS__SELF_POSE_LISTENER_HPP_
 
+#include <memory>
+
 #include "rclcpp/rclcpp.hpp"
 
 #include "autoware_utils/geometry/geometry.hpp"

--- a/common/util/autoware_utils/include/autoware_utils/ros/self_pose_listener.hpp
+++ b/common/util/autoware_utils/include/autoware_utils/ros/self_pose_listener.hpp
@@ -25,7 +25,8 @@ namespace autoware_utils
 class SelfPoseListener
 {
 public:
-  explicit SelfPoseListener(rclcpp::Node * node) : transform_listener_(node) {}
+  explicit SelfPoseListener(rclcpp::Node * node)
+  : transform_listener_(node) {}
 
   void waitForFirstPose()
   {

--- a/common/util/autoware_utils/include/autoware_utils/ros/self_pose_listener.hpp
+++ b/common/util/autoware_utils/include/autoware_utils/ros/self_pose_listener.hpp
@@ -25,37 +25,27 @@ namespace autoware_utils
 class SelfPoseListener
 {
 public:
-  explicit SelfPoseListener(rclcpp::Node * node)
-  : transform_listener_(node) {}
+  explicit SelfPoseListener(rclcpp::Node * node) : transform_listener_(node) {}
+
   void waitForFirstPose()
   {
     while (rclcpp::ok()) {
-      const auto pose = getPoseAt(rclcpp::Time(0), rclcpp::Duration::from_seconds(5.0));
-      if (pose) {
+      if (getCurrentPose()) {
         return;
       }
       RCLCPP_INFO(transform_listener_.getLogger(), "waiting for self pose...");
+      rclcpp::Rate(0.2).sleep();
     }
   }
 
   geometry_msgs::msg::PoseStamped::ConstSharedPtr getCurrentPose()
   {
-    return getPoseAt(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.0));
-  }
-
-  geometry_msgs::msg::PoseStamped::ConstSharedPtr getPoseAt(
-    const rclcpp::Time & time, const rclcpp::Duration & duration)
-  {
-    const auto tf = transform_listener_.getTransform("map", "base_link", time, duration);
-
+    const auto tf = transform_listener_.getLatestTransform("map", "base_link");
     if (!tf) {
       return {};
     }
 
-    geometry_msgs::msg::PoseStamped::SharedPtr pose(new geometry_msgs::msg::PoseStamped());
-    *pose = transform2pose(*tf);
-
-    return geometry_msgs::msg::PoseStamped::ConstSharedPtr(pose);
+    return std::make_shared<const geometry_msgs::msg::PoseStamped>(transform2pose(*tf));
   }
 
 private:

--- a/common/util/autoware_utils/include/autoware_utils/ros/transform_listener.hpp
+++ b/common/util/autoware_utils/include/autoware_utils/ros/transform_listener.hpp
@@ -37,6 +37,22 @@ public:
     tf_buffer_->setCreateTimerInterface(timer_interface);
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
   }
+
+  geometry_msgs::msg::TransformStamped::ConstSharedPtr getLatestTransform(
+    const std::string & from, const std::string & to)
+  {
+    geometry_msgs::msg::TransformStamped tf;
+    try {
+      tf = tf_buffer_->lookupTransform(from, to, tf2::TimePointZero);
+    } catch (tf2::TransformException & ex) {
+      RCLCPP_WARN(
+        logger_, "failed to get transform from %s to %s: %s", from.c_str(), to.c_str(), ex.what());
+      return {};
+    }
+
+    return std::make_shared<const geometry_msgs::msg::TransformStamped>(tf);
+  }
+
   geometry_msgs::msg::TransformStamped::ConstSharedPtr getTransform(
     const std::string & from, const std::string & to, const rclcpp::Time & time,
     const rclcpp::Duration & duration)
@@ -50,13 +66,10 @@ public:
       return {};
     }
 
-    geometry_msgs::msg::TransformStamped::SharedPtr transform(
-      new geometry_msgs::msg::TransformStamped());
-    *transform = tf;
-
-    return transform;
+    return std::make_shared<const geometry_msgs::msg::TransformStamped>(tf);
   }
-  rclcpp::Logger getLogger() {return logger_;}
+
+  rclcpp::Logger getLogger() { return logger_; }
 
 private:
   rclcpp::Clock::SharedPtr clock_;

--- a/common/util/autoware_utils/include/autoware_utils/ros/transform_listener.hpp
+++ b/common/util/autoware_utils/include/autoware_utils/ros/transform_listener.hpp
@@ -69,7 +69,7 @@ public:
     return std::make_shared<const geometry_msgs::msg::TransformStamped>(tf);
   }
 
-  rclcpp::Logger getLogger() { return logger_; }
+  rclcpp::Logger getLogger() {return logger_;}
 
 private:
   rclcpp::Clock::SharedPtr clock_;


### PR DESCRIPTION
This resolves console spam errors like this.

```sh
[lane_departure_checker_node-43] Warning: Invalid frame ID "map" passed to canTransform argument target_frame - frame does not exist
[lane_departure_checker_node-43]          at line 133 in /tmp/binarydeb/ros-foxy-tf2-0.13.9/src/buffer_core.cpp
[lane_departure_checker_node-43] Warning: Invalid frame ID "map" passed to canTransform argument target_frame - frame does not exist
[lane_departure_checker_node-43]          at line 133 in /tmp/binarydeb/ros-foxy-tf2-0.13.9/src/buffer_core.cpp
[lane_departure_checker_node-43] Warning: Invalid frame ID "map" passed to canTransform argument target_frame - frame does not exist
[lane_departure_checker_node-43]          at line 133 in /tmp/binarydeb/ros-foxy-tf2-0.13.9/src/buffer_core.cpp
[lane_departure_checker_node-43] Warning: Invalid frame ID "map" passed to canTransform argument target_frame - frame does not exist
[lane_departure_checker_node-43]          at line 133 in /tmp/binarydeb/ros-foxy-tf2-0.13.9/src/buffer_core.cpp
[lane_departure_checker_node-43] Warning: Invalid frame ID "map" passed to canTransform argument target_frame - frame does not exist
[lane_departure_checker_node-43]          at line 133 in /tmp/binarydeb/ros-foxy-tf2-0.13.9/src/buffer_core.cpp
[lane_departure_checker_node-43] Warning: Invalid frame ID "map" passed to canTransform argument target_frame - frame does not exist
[lane_departure_checker_node-43]          at line 133 in /tmp/binarydeb/ros-foxy-tf2-0.13.9/src/buffer_core.cpp
[lane_departure_checker_node-43] Warning: Invalid frame ID "map" passed to canTransform argument target_frame - frame does not exist
[lane_departure_checker_node-43]          at line 133 in /tmp/binarydeb/ros-foxy-tf2-0.13.9/src/buffer_core.cpp
[lane_departure_checker_node-43] Warning: Invalid frame ID "map" passed to canTransform argument target_frame - frame does not exist
[lane_departure_checker_node-43]          at line 133 in /tmp/binarydeb/ros-foxy-tf2-0.13.9/src/buffer_core.cpp
[lane_departure_checker_node-43] Warning: Invalid frame ID "map" passed to canTransform argument target_frame - frame does not exist
[lane_departure_checker_node-43]          at line 133 in /tmp/binarydeb/ros-foxy-tf2-0.13.9/src/buffer_core.cpp
```