### PR TITLE
Fix typo in control module

### DIFF
--- a/control/mpc_follower/README.md
+++ b/control/mpc_follower/README.md
@@ -46,8 +46,8 @@ The default parameters are adjusted to the AutonomouStuff Lexus RX 450h for unde
 |path_smoothing_times|int|number of times of applying path smoothing filter|1|
 |curvature_smoothing_num|double|index distance of points used in curvature calculation: p(i-num), p(i), p(i+num). larger num makes less noisy values.|35|
 |steering_lpf_cutoff_hz|double| cutoff frequency of lowpass filter for steering output command [hz]|3.0|
-|admisible_position_error|double| stop vehicle when following position error is larger than this value [m].|5.0|
-|admisible_yaw_error_deg|double|stop vehicle when following yaw angle error is larger than this value [deg].|90.0|
+|admissible_position_error|double| stop vehicle when following position error is larger than this value [m].|5.0|
+|admissible_yaw_error_deg|double|stop vehicle when following yaw angle error is larger than this value [deg].|90.0|
 
 ## mpc algorithm 
 

--- a/control/mpc_follower/README.md
+++ b/control/mpc_follower/README.md
@@ -8,7 +8,7 @@ There are 2 nodes related to MPC follower.
  - `/mpc_waypoint_converter` : converts `/final_waypoints` to `/mpc_waypoints` which includes waypoints behind the self position. This is to solve temporary conflict of planning system and mpc follower so that mpc follower can be used in the same way as pure_pursuit. This will be removed in a future release.
  - `/mpc_follower` : generates control command (`/twist_raw` or/and `/ctrl_raw`) to follow `/mpc_waypoints`.
 
-[Video](https://www.youtube.com/watch?v=4IO1zxsY4wU&t=18s) : comparison of pure_pursuit and mpc_follower with gazebo simulation. 
+[Video](https://www.youtube.com/watch?v=4IO1zxsY4wU&t=18s) : comparison of pure_pursuit and mpc_follower with gazebo simulation.
 
 
 
@@ -33,7 +33,7 @@ There are 2 nodes related to MPC follower.
 The default parameters are adjusted to the AutonomouStuff Lexus RX 450h for under 40 km/h driving.
 
 
-## overall 
+## overall
 
 |Name|Type|Description|Default value|
 |:---|:---|:---|:---|
@@ -47,9 +47,9 @@ The default parameters are adjusted to the AutonomouStuff Lexus RX 450h for unde
 |curvature_smoothing_num|double|index distance of points used in curvature calculation: p(i-num), p(i), p(i+num). larger num makes less noisy values.|35|
 |steering_lpf_cutoff_hz|double| cutoff frequency of lowpass filter for steering output command [hz]|3.0|
 |admissible_position_error|double| stop vehicle when following position error is larger than this value [m].|5.0|
-|admissible_yaw_error_rad|double|stop vehicle when following yaw angle error is larger than this value [rad].|90.0|
+|admissible_yaw_error_rad|double|stop vehicle when following yaw angle error is larger than this value [rad].|1.57|
 
-## mpc algorithm 
+## mpc algorithm
 
 |Name|Type|Description|Default value|
 |:---|:---|:---|:---|
@@ -112,6 +112,6 @@ Other parameters can be adjusted like below.
  - `weight_terminal_lat_error`: Preferable to set a higher value than normal lateral weight `weight_lat_error` for stability.
  - `weight_terminal_heading_error`: Preferable to set a higher value than normal heading weight `weight_heading_error` for stability.
 
- # reference 
+ # reference
 
  [1] Jarrod M. Snider, "Automatic Steering Methods for Autonomous Automobile Path Tracking", Robotics Institute, Carnegie Mellon University, February 2009.

--- a/control/mpc_follower/README.md
+++ b/control/mpc_follower/README.md
@@ -47,7 +47,7 @@ The default parameters are adjusted to the AutonomouStuff Lexus RX 450h for unde
 |curvature_smoothing_num|double|index distance of points used in curvature calculation: p(i-num), p(i), p(i+num). larger num makes less noisy values.|35|
 |steering_lpf_cutoff_hz|double| cutoff frequency of lowpass filter for steering output command [hz]|3.0|
 |admissible_position_error|double| stop vehicle when following position error is larger than this value [m].|5.0|
-|admissible_yaw_error_deg|double|stop vehicle when following yaw angle error is larger than this value [deg].|90.0|
+|admissible_yaw_error_rad|double|stop vehicle when following yaw angle error is larger than this value [rad].|90.0|
 
 ## mpc algorithm 
 

--- a/control/mpc_follower/cfg/MPCFollower.cfg
+++ b/control/mpc_follower/cfg/MPCFollower.cfg
@@ -33,7 +33,7 @@ gen.add("steer_rate_lim_dps", double_t, 0, "steering angle rate limit [deg/s]", 
 gen.add("acceleration_limit", double_t, 0, "acceleration limit for trajectory velocity modification [m/ss]", 2.0, 0.01, 10.0)
 gen.add("velocity_time_constant", double_t, 0, "velocity dynamics time constant  for trajectory velocity modification [s]", 0.3, 0.01, 10.0)
 gen.add("input_delay", double_t, 0, "steering input delay time for delay compensation", 0.24, 0.0, 3.0)
-# gen.add("vehicle_model_steer_tau", double_t, 0, "steering dynamics time constant (1d approzimation) [s]", 0.3, 0.0, 3.0)
+# gen.add("vehicle_model_steer_tau", double_t, 0, "steering dynamics time constant (1d approximation) [s]", 0.3, 0.0, 3.0)
 # gen.add("steering_lpf_cutoff_hz", double_t, 0, "cutoff frequency of lowpass filter for steering command [Hz]", 3.0, 0.0, 10.0)
 
 

--- a/control/mpc_follower/config/mpc_follower.param.yaml
+++ b/control/mpc_follower/config/mpc_follower.param.yaml
@@ -7,7 +7,7 @@
     enable_yaw_recalculation: false # flag for recalculation of yaw angle after resampling
     use_steer_prediction: false     # flag for using steer prediction (do not use steer measurement)
     admissible_position_error: 5.0  # stop mpc calculation when error is larger than the following value
-    admissible_yaw_error_: 1.57     # stop mpc calculation when error is larger than the following value
+    admissible_yaw_error_rad: 1.57  # stop mpc calculation when error is larger than the following value
 
     # -- path smoothing --
     enable_path_smoothing: false   # flag for path smoothing

--- a/control/mpc_follower/config/mpc_follower.param.yaml
+++ b/control/mpc_follower/config/mpc_follower.param.yaml
@@ -6,8 +6,8 @@
     traj_resample_dist: 0.1         # path resampling interval [m]
     enable_yaw_recalculation: false # flag for recalculation of yaw angle after resampling
     use_steer_prediction: false     # flag for using steer prediction (do not use steer measurement)
-    admisible_position_error: 5.0   # stop mpc calculation when error is larger than the following value
-    admisible_yaw_error_: 1.57      # stop mpc calculation when error is larger than the following value
+    admissible_position_error: 5.0  # stop mpc calculation when error is larger than the following value
+    admissible_yaw_error_: 1.57     # stop mpc calculation when error is larger than the following value
 
     # -- path smoothing --
     enable_path_smoothing: false   # flag for path smoothing

--- a/control/mpc_follower/include/mpc_follower/mpc_follower_core.hpp
+++ b/control/mpc_follower/include/mpc_follower/mpc_follower_core.hpp
@@ -91,9 +91,9 @@ private:
   rclcpp::Subscription<autoware_planning_msgs::msg::Trajectory>::SharedPtr
     sub_ref_path_;  //!< @brief topic subscription for reference waypoints
   rclcpp::Subscription<autoware_vehicle_msgs::msg::Steering>::SharedPtr
-    sub_steering_;  //!< @brief subscription for currrent steering
+    sub_steering_;  //!< @brief subscription for current steering
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr
-    sub_current_vel_;  //!< @brief subscription for currrent velocity
+    sub_current_vel_;  //!< @brief subscription for current velocity
 
   rclcpp::TimerBase::SharedPtr timer_;  //!< @brief timer to update after a given interval
   void initTimer(double period_s);  //!< initialize timer to work in real, simulation, and replay
@@ -110,8 +110,8 @@ private:
   /* parameters for control*/
   double ctrl_period_;               //!< @brief control frequency [s]
   double steering_lpf_cutoff_hz_;    //!< @brief cutoff frequency for steering command [Hz]
-  double admisible_position_error_;  //!< @brief use stop cmd when lateral error exceeds this [m]
-  double admisible_yaw_error_;       //!< @briefuse stop cmd when yaw error exceeds this [rad]
+  double admissible_position_error_; //!< @brief use stop cmd when lateral error exceeds this [m]
+  double admissible_yaw_error_;      //!< @briefuse stop cmd when yaw error exceeds this [rad]
   double steer_lim_;                 //!< @brief steering command limit [rad]
   double steer_rate_lim_;            //!< @brief steering rate limit [rad/s]
   double wheelbase_;                 //!< @brief vehicle wheelbase length [m]

--- a/control/mpc_follower/include/mpc_follower/mpc_follower_core.hpp
+++ b/control/mpc_follower/include/mpc_follower/mpc_follower_core.hpp
@@ -111,7 +111,7 @@ private:
   double ctrl_period_;               //!< @brief control frequency [s]
   double steering_lpf_cutoff_hz_;    //!< @brief cutoff frequency for steering command [Hz]
   double admissible_position_error_; //!< @brief use stop cmd when lateral error exceeds this [m]
-  double admissible_yaw_error_;      //!< @briefuse stop cmd when yaw error exceeds this [rad]
+  double admissible_yaw_error_rad_;  //!< @briefuse stop cmd when yaw error exceeds this [rad]
   double steer_lim_;                 //!< @brief steering command limit [rad]
   double steer_rate_lim_;            //!< @brief steering rate limit [rad/s]
   double wheelbase_;                 //!< @brief vehicle wheelbase length [m]

--- a/control/mpc_follower/src/mpc_follower_core.cpp
+++ b/control/mpc_follower/src/mpc_follower_core.cpp
@@ -54,7 +54,7 @@ MPCFollower::MPCFollower()
   curvature_smoothing_num_ = declare_parameter("curvature_smoothing_num", 35);
   traj_resample_dist_ = declare_parameter("traj_resample_dist", 0.1);  // [m]
   admissible_position_error_ = declare_parameter("admissible_position_error", 5.0);
-  admissible_yaw_error_ = declare_parameter("admissible_yaw_error", M_PI_2);
+  admissible_yaw_error_rad_ = declare_parameter("admissible_yaw_error_rad", M_PI_2);
   use_steer_prediction_ = declare_parameter("use_steer_prediction", false);
   mpc_param_.steer_tau = declare_parameter("vehicle_model_steer_tau", 0.1);
 
@@ -417,10 +417,10 @@ bool MPCFollower::getData(const MPCTrajectory & traj, MPCData * data)
   }
 
   /* check yaw error limit */
-  if (std::fabs(data->yaw_err) > admissible_yaw_error_) {
+  if (std::fabs(data->yaw_err) > admissible_yaw_error_rad_) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), duration, "yaw error is over limit. error = %fdeg, limit %fdeg",
-      RAD2DEG * data->yaw_err, RAD2DEG * admissible_yaw_error_);
+      RAD2DEG * data->yaw_err, RAD2DEG * admissible_yaw_error_rad_);
     return false;
   }
 

--- a/control/mpc_follower/src/mpc_follower_core.cpp
+++ b/control/mpc_follower/src/mpc_follower_core.cpp
@@ -53,8 +53,8 @@ MPCFollower::MPCFollower()
   path_filter_moving_ave_num_ = declare_parameter("path_filter_moving_ave_num", 35);
   curvature_smoothing_num_ = declare_parameter("curvature_smoothing_num", 35);
   traj_resample_dist_ = declare_parameter("traj_resample_dist", 0.1);  // [m]
-  admisible_position_error_ = declare_parameter("admisible_position_error", 5.0);
-  admisible_yaw_error_ = declare_parameter("admisible_yaw_error", M_PI_2);
+  admissible_position_error_ = declare_parameter("admissible_position_error", 5.0);
+  admissible_yaw_error_ = declare_parameter("admissible_yaw_error", M_PI_2);
   use_steer_prediction_ = declare_parameter("use_steer_prediction", false);
   mpc_param_.steer_tau = declare_parameter("vehicle_model_steer_tau", 0.1);
 
@@ -409,18 +409,18 @@ bool MPCFollower::getData(const MPCTrajectory & traj, MPCData * data)
 
   /* check error limit */
   const double dist_err = MPCUtils::calcDist2d(current_pose_ptr_->pose, data->nearest_pose);
-  if (dist_err > admisible_position_error_) {
+  if (dist_err > admissible_position_error_) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), duration, "position error is over limit. error = %fm, limit: %fm",
-      dist_err, admisible_position_error_);
+      dist_err, admissible_position_error_);
     return false;
   }
 
   /* check yaw error limit */
-  if (std::fabs(data->yaw_err) > admisible_yaw_error_) {
+  if (std::fabs(data->yaw_err) > admissible_yaw_error_) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), duration, "yaw error is over limit. error = %fdeg, limit %fdeg",
-      RAD2DEG * data->yaw_err, RAD2DEG * admisible_yaw_error_);
+      RAD2DEG * data->yaw_err, RAD2DEG * admissible_yaw_error_);
     return false;
   }
 

--- a/control/trajectory_follower/lane_departure_checker/include/lane_departure_checker/lane_departure_checker_node.hpp
+++ b/control/trajectory_follower/lane_departure_checker/include/lane_departure_checker/lane_departure_checker_node.hpp
@@ -62,7 +62,7 @@ private:
   geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose_;
   geometry_msgs::msg::TwistStamped::ConstSharedPtr current_twist_;
   lanelet::LaneletMapPtr lanelet_map_;
-  lanelet::traffic_rules::TrafficRulesPtr traffif_rules_;
+  lanelet::traffic_rules::TrafficRulesPtr traffic_rules_;
   lanelet::routing::RoutingGraphPtr routing_graph_;
   autoware_planning_msgs::msg::Route::ConstSharedPtr route_;
   autoware_planning_msgs::msg::Route::ConstSharedPtr last_route_;

--- a/control/trajectory_follower/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/trajectory_follower/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -57,11 +57,11 @@ lanelet::ConstLanelets getRouteLanelets(
 
   // Add preceding lanes of front route_section to prevent detection errors
   {
-    const auto extention_length = 2 * vehicle_length;
+    const auto extension_length = 2 * vehicle_length;
 
     for (const auto & lane_id : route_sections.front().lane_ids) {
       for (const auto & lanelet_sequence : lanelet::utils::query::getPrecedingLaneletSequences(
-          routing_graph, lanelet_map.laneletLayer.get(lane_id), extention_length))
+          routing_graph, lanelet_map.laneletLayer.get(lane_id), extension_length))
       {
         for (const auto & preceding_lanelet : lanelet_sequence) {
           route_lanelets.push_back(preceding_lanelet);
@@ -78,11 +78,11 @@ lanelet::ConstLanelets getRouteLanelets(
 
   // Add succeeding lanes of last route_section to prevent detection errors
   {
-    const auto extention_length = 2 * vehicle_length;
+    const auto extension_length = 2 * vehicle_length;
 
     for (const auto & lane_id : route_sections.back().lane_ids) {
       for (const auto & lanelet_sequence : lanelet::utils::query::getSucceedingLaneletSequences(
-          routing_graph, lanelet_map.laneletLayer.get(lane_id), extention_length))
+          routing_graph, lanelet_map.laneletLayer.get(lane_id), extension_length))
       {
         for (const auto & succeeding_lanelet : lanelet_sequence) {
           route_lanelets.push_back(succeeding_lanelet);
@@ -210,7 +210,7 @@ void LaneDepartureCheckerNode::onLaneletMapBin(
   const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg)
 {
   lanelet_map_ = std::make_shared<lanelet::LaneletMap>();
-  lanelet::utils::conversion::fromBinMsg(*msg, lanelet_map_, &traffif_rules_, &routing_graph_);
+  lanelet::utils::conversion::fromBinMsg(*msg, lanelet_map_, &traffic_rules_, &routing_graph_);
 }
 
 void LaneDepartureCheckerNode::onRoute(const autoware_planning_msgs::msg::Route::ConstSharedPtr msg)
@@ -354,7 +354,7 @@ rcl_interfaces::msg::SetParametersResult LaneDepartureCheckerNode::onParameter(
 
   try {
     // Node
-    update_param(parameters, "vizualize_lanelet", node_param_.visualize_lanelet);
+    update_param(parameters, "visualize_lanelet", node_param_.visualize_lanelet);
 
     // Core
     update_param(parameters, "footprint_margin", param_.footprint_margin);


### PR DESCRIPTION
Fix typo in the control module.
Please merge this with the following pull request simultaneously.
https://github.com/tier4/autoware_launcher.iv.universe/pull/91