### PR TITLE
Add depend tag for image_transport_plugins

### DIFF
--- a/control/trajectory_follower/lane_departure_checker/package.xml
+++ b/control/trajectory_follower/lane_departure_checker/package.xml
@@ -22,6 +22,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>vehicle_info_util</depend>
+  <depend>image_transport_plugins</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Fix runtime error: `terminate called after throwing an instance of 'image_transport::TransportLoadException'`                                                                                                                                                                       


