### PR TITLE
Fix typo in system module

### DIFF
--- a/system/autoware_error_monitor/config/diagnostic_aggregator/sensing.param.yaml
+++ b/system/autoware_error_monitor/config/diagnostic_aggregator/sensing.param.yaml
@@ -73,7 +73,7 @@
                 firmware_staus:
                   type: diagnostic_aggregator/GenericAnalyzer
                   path: firmware_staus
-                  contains: [": livox_firmware_staus"]
+                  contains: [": livox_firmware_status"]
                   timeout: 3.0
                   num_items: 0
                 pps_signal:

--- a/system/autoware_state_monitor/config/autoware_state_monitor.param.yaml
+++ b/system/autoware_state_monitor/config/autoware_state_monitor.param.yaml
@@ -87,7 +87,7 @@
           type: "autoware_perception_msgs/msg/DynamicObjectArray"
           # This topic could have two different types depending on the launch flags used.
           # The implementation of subscriptions in ROS2 does not allow for multiple types
-          # to be defined for a topic. By default the this is set to not use have features.
+          # to be defined for a topic. By default this is set to not use have features.
           # type: ["autoware_perception_msgs/msg/DynamicObjectArray", "autoware_perception_msgs/msg/DynamicObjectWithFeatureArray"]
 
         /planning/mission_planning/route:

--- a/system/system_monitor/include/system_monitor/utils.hpp
+++ b/system/system_monitor/include/system_monitor/utils.hpp
@@ -29,7 +29,7 @@
 /// \tparam MonitorT Monitor type
 /// \param monitor_ptr Shared pointer of a monitor node to be spin().
 /// \param period Spin period.
-template <typename MonitorT>
+template<typename MonitorT>
 void spin_and_update(const std::shared_ptr<MonitorT> & monitor_ptr, std::chrono::seconds period)
 {
   while (rclcpp::ok()) {

--- a/system/system_monitor/include/system_monitor/utils.hpp
+++ b/system/system_monitor/include/system_monitor/utils.hpp
@@ -19,7 +19,7 @@
 
 /// This function will spin the given node and update the diagnostic state at each iteration
 /// \tparam MonitorT Monitor type
-/// \param monitor_ptr Shared pointer of a monitor node to be spinned.
+/// \param monitor_ptr Shared pointer of a monitor node to be spin().
 /// \param period Spin period.
 
 #ifndef SYSTEM_MONITOR__UTILS_HPP_

--- a/system/system_monitor/include/system_monitor/utils.hpp
+++ b/system/system_monitor/include/system_monitor/utils.hpp
@@ -17,20 +17,19 @@
  * @brief Utility functions used by different system monitor nodes.
  */
 
+#ifndef SYSTEM_MONITOR__UTILS_HPP_
+#define SYSTEM_MONITOR__UTILS_HPP_
+
+#include <chrono>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
 /// This function will spin the given node and update the diagnostic state at each iteration
 /// \tparam MonitorT Monitor type
 /// \param monitor_ptr Shared pointer of a monitor node to be spin().
 /// \param period Spin period.
-
-#ifndef SYSTEM_MONITOR__UTILS_HPP_
-#define SYSTEM_MONITOR__UTILS_HPP_
-
-#include <memory>
-#include <chrono>
-
-#include "rclcpp/rclcpp.hpp"
-
-template<typename MonitorT>
+template <typename MonitorT>
 void spin_and_update(const std::shared_ptr<MonitorT> & monitor_ptr, std::chrono::seconds period)
 {
   while (rclcpp::ok()) {

--- a/system/system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/system_monitor/src/net_monitor/net_monitor.cpp
@@ -86,7 +86,7 @@ void NetMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
   float tx_traffic;
   float rx_usage;
   float tx_usage;
-  std::vector<std::string> appended;
+  std::vector<std::string> interface_names;
 
   for (ifa = ifas; ifa; ifa = ifa->ifa_next) {
     // Skip no addr
@@ -124,7 +124,7 @@ void NetMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
       ++index;
       close(fd);
-      appended.push_back(ifa->ifa_name);
+      interface_names.push_back(ifa->ifa_name);
       continue;
     }
 
@@ -149,7 +149,7 @@ void NetMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
         ++index;
         close(fd);
-        appended.push_back(ifa->ifa_name);
+        interface_names.push_back(ifa->ifa_name);
         continue;
       }
     } else {
@@ -190,7 +190,7 @@ void NetMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
     ++index;
 
-    appended.push_back(ifa->ifa_name);
+    interface_names.push_back(ifa->ifa_name);
   }
 
   freeifaddrs(ifas);
@@ -200,7 +200,7 @@ void NetMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
     // Skip if all devices specified
     if (device == "*") {continue;}
     // Skip if device already appended
-    if (boost::find(appended, device) != appended.end()) {continue;}
+    if (boost::find(interface_names, device) != interface_names.end()) {continue;}
 
     stat.add(fmt::format("Network {}: status", index), "No Such Device");
     stat.add(fmt::format("Network {}: interface name", index), device);

--- a/system/system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/system_monitor/src/net_monitor/net_monitor.cpp
@@ -86,7 +86,7 @@ void NetMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
   float tx_traffic;
   float rx_usage;
   float tx_usage;
-  std::vector<std::string> entried;
+  std::vector<std::string> appended;
 
   for (ifa = ifas; ifa; ifa = ifa->ifa_next) {
     // Skip no addr
@@ -124,7 +124,7 @@ void NetMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
       ++index;
       close(fd);
-      entried.push_back(ifa->ifa_name);
+      appended.push_back(ifa->ifa_name);
       continue;
     }
 
@@ -149,7 +149,7 @@ void NetMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
         ++index;
         close(fd);
-        entried.push_back(ifa->ifa_name);
+        appended.push_back(ifa->ifa_name);
         continue;
       }
     } else {
@@ -190,7 +190,7 @@ void NetMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
     ++index;
 
-    entried.push_back(ifa->ifa_name);
+    appended.push_back(ifa->ifa_name);
   }
 
   freeifaddrs(ifas);
@@ -199,8 +199,8 @@ void NetMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
   for (const auto & device : device_params_) {
     // Skip if all devices specified
     if (device == "*") {continue;}
-    // Skip if device already entried
-    if (boost::find(entried, device) != entried.end()) {continue;}
+    // Skip if device already appended
+    if (boost::find(appended, device) != appended.end()) {continue;}
 
     stat.add(fmt::format("Network {}: status", index), "No Such Device");
     stat.add(fmt::format("Network {}: interface name", index), device);


### PR DESCRIPTION
Fix typo in system module.

@ito-san 
The followings are just my humble suggestion. Do you have any other good words to replace them?
- entried -> appended
- spinned -> spin()
