### PR TITLE
avoid pushing empty marker

### DIFF
--- a/map/lanelet2_extension/lib/visualization.cpp
+++ b/map/lanelet2_extension/lib/visualization.cpp
@@ -787,13 +787,13 @@ visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArra
   }
 
   visualization_msgs::msg::MarkerArray marker_array;
-  if (left_line_strip.points.size() > 0) {
+  if (!left_line_strip.points.empty()) {
     marker_array.markers.push_back(left_line_strip);
   }
-  if (right_line_strip.points.size() > 0) {
+  if (!right_line_strip.points.empty()) {
     marker_array.markers.push_back(right_line_strip);
   }
-  if (center_line_strip.points.size() > 0) {
+  if (!center_line_strip.points.empty()) {
     marker_array.markers.push_back(center_line_strip);
   }
   return marker_array;

--- a/map/lanelet2_extension/lib/visualization.cpp
+++ b/map/lanelet2_extension/lib/visualization.cpp
@@ -787,9 +787,15 @@ visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArra
   }
 
   visualization_msgs::msg::MarkerArray marker_array;
-  marker_array.markers.push_back(left_line_strip);
-  marker_array.markers.push_back(right_line_strip);
-  marker_array.markers.push_back(center_line_strip);
+  if (left_line_strip.points.size() > 0) {
+    marker_array.markers.push_back(left_line_strip);
+  }
+  if (right_line_strip.points.size() > 0) {
+    marker_array.markers.push_back(right_line_strip);
+  }
+  if (center_line_strip.points.size() > 0) {
+    marker_array.markers.push_back(center_line_strip);
+  }
   return marker_array;
 }
 


### PR DESCRIPTION
Remove Route Area Error at containg empty points marker
 
![image](https://user-images.githubusercontent.com/65527974/111298794-859df180-8692-11eb-9c82-338cf186631c.png)

