### PR TITLE
Ros2 fix ndt align srv

### DIFF
--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -209,13 +209,17 @@ void NDTScanMatcher::serviceNDTAlign(
   tf2::doTransform(req->pose_with_cov, *mapTF_initial_pose_msg_ptr, *TF_pose_to_map_ptr);
 
   if (ndt_ptr_->getInputTarget() == nullptr) {
-    // TODO wait for map pointcloud
-    throw std::runtime_error("No InputTarget");
+    res->success = false;
+    res->seq = req->seq;
+    RCLCPP_WARN(get_logger(), "No InputTarget");
+    return;
   }
 
   if (ndt_ptr_->getInputSource() == nullptr) {
-    // TODO wait for sensor pointcloud
-    throw std::runtime_error("No InputSource");
+    res->success = false;
+    res->seq = req->seq;
+    RCLCPP_WARN(get_logger(), "No InputSource");
+    return;
   }
 
   // mutex Map
@@ -224,6 +228,7 @@ void NDTScanMatcher::serviceNDTAlign(
   key_value_stdmap_["state"] = "Aligning";
   res->pose_with_cov = alignUsingMonteCarlo(ndt_ptr_, *mapTF_initial_pose_msg_ptr);
   key_value_stdmap_["state"] = "Sleeping";
+  res->success = true;
   res->seq = req->seq;
   res->pose_with_cov.pose.covariance = req->pose_with_cov.pose.covariance;
 }

--- a/localization/util/autoware_localization_srvs/srv/PoseWithCovarianceStamped.srv
+++ b/localization/util/autoware_localization_srvs/srv/PoseWithCovarianceStamped.srv
@@ -2,5 +2,6 @@
 uint32 seq
 geometry_msgs/PoseWithCovarianceStamped pose_with_cov
 ---
+bool success
 uint32 seq
 geometry_msgs/PoseWithCovarianceStamped pose_with_cov

--- a/localization/util/pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/util/pose_initializer/src/pose_initializer_core.cpp
@@ -207,8 +207,7 @@ void PoseInitializer::callAlignServiceAndPublishResult(
     req,
     [this](rclcpp::Client<autoware_localization_srvs::srv::PoseWithCovarianceStamped>::SharedFuture
     result) {
-      if (result.get()->success)
-      {
+      if (result.get()->success) {
         RCLCPP_INFO(get_logger(), "called NDT Align Server");
         response_id_ = result.get()->seq;
         // NOTE temporary cov
@@ -221,9 +220,7 @@ void PoseInitializer::callAlignServiceAndPublishResult(
         pose_with_cov.pose.covariance[5 * 6 + 5] = 0.2;
         initial_pose_pub_->publish(pose_with_cov);
         enable_gnss_callback_ = false;
-      }
-      else
-      {
+      } else {
         RCLCPP_INFO(get_logger(), "failed NDT Align Server");
         response_id_ = result.get()->seq;
       }

--- a/localization/util/pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/util/pose_initializer/src/pose_initializer_core.cpp
@@ -207,17 +207,25 @@ void PoseInitializer::callAlignServiceAndPublishResult(
     req,
     [this](rclcpp::Client<autoware_localization_srvs::srv::PoseWithCovarianceStamped>::SharedFuture
     result) {
-      RCLCPP_INFO(get_logger(), "called NDT Align Server");
-      response_id_ = result.get()->seq;
-      // NOTE temporary cov
-      geometry_msgs::msg::PoseWithCovarianceStamped & pose_with_cov = result.get()->pose_with_cov;
-      pose_with_cov.pose.covariance[0] = 1.0;
-      pose_with_cov.pose.covariance[1 * 6 + 1] = 1.0;
-      pose_with_cov.pose.covariance[2 * 6 + 2] = 0.01;
-      pose_with_cov.pose.covariance[3 * 6 + 3] = 0.01;
-      pose_with_cov.pose.covariance[4 * 6 + 4] = 0.01;
-      pose_with_cov.pose.covariance[5 * 6 + 5] = 0.2;
-      initial_pose_pub_->publish(pose_with_cov);
-      enable_gnss_callback_ = false;
+      if (result.get()->success)
+      {
+        RCLCPP_INFO(get_logger(), "called NDT Align Server");
+        response_id_ = result.get()->seq;
+        // NOTE temporary cov
+        geometry_msgs::msg::PoseWithCovarianceStamped & pose_with_cov = result.get()->pose_with_cov;
+        pose_with_cov.pose.covariance[0] = 1.0;
+        pose_with_cov.pose.covariance[1 * 6 + 1] = 1.0;
+        pose_with_cov.pose.covariance[2 * 6 + 2] = 0.01;
+        pose_with_cov.pose.covariance[3 * 6 + 3] = 0.01;
+        pose_with_cov.pose.covariance[4 * 6 + 4] = 0.01;
+        pose_with_cov.pose.covariance[5 * 6 + 5] = 0.2;
+        initial_pose_pub_->publish(pose_with_cov);
+        enable_gnss_callback_ = false;
+      }
+      else
+      {
+        RCLCPP_INFO(get_logger(), "failed NDT Align Server");
+        response_id_ = result.get()->seq;
+      }
     });
 }


### PR DESCRIPTION
Fix this runtime error.
```
[ndt_scan_matcher-34] terminate called after throwing an instance of 'std::runtime_error'
[ndt_scan_matcher-34]   what():  No InputSource
```