### PR TITLE
fix licence typo in image_transport_decompressor

### DIFF
--- a/sensing/preprocessor/image/image_transport_decompressor/src/nodelet.cpp
+++ b/sensing/preprocessor/image/image_transport_decompressor/src/nodelet.cpp
@@ -17,7 +17,7 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
 * 
-*  Copyright (c) 20012, Willow Garage, Inc.
+*  Copyright (c) 2012, Willow Garage, Inc.
 *  All rights reserved.
 * 
 *  Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
There is a typo in licence, I fixed it.