### PR TITLE
Ros2 vehicle info param server

### DIFF
--- a/control/mpc_follower/launch/mpc_follower.launch.xml
+++ b/control/mpc_follower/launch/mpc_follower.launch.xml
@@ -1,13 +1,11 @@
 <launch>
 
   <arg name="mpc_follower_param_path" default="$(find-pkg-share mpc_follower)/config/mpc_follower.param.yaml"/>
-  <arg name="vehicle_param_file"/>
 
   <!-- mpc for trajectory following -->
   <node pkg="mpc_follower" exec="mpc_follower" name="mpc_follower" output="screen">
     <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var mpc_follower_param_path)"/>
-    <param from="$(var vehicle_param_file)" />
     <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
     <remap from="~/input/current_velocity" to="/localization/twist"/>
     <remap from="~/input/current_steering" to="/vehicle/status/steering"/>

--- a/control/pure_pursuit/launch/pure_pursuit.launch.xml
+++ b/control/pure_pursuit/launch/pure_pursuit.launch.xml
@@ -1,7 +1,6 @@
 <launch>
 
   <arg name="pure_pursuit_param_path" default="$(find-pkg-share pure_pursuit)/config/pure_pursuit.param.yaml"/>
-  <arg name="vehicle_param_file"/>
 
   <arg name="input/reference_trajectory" default="/planning/scenario_planning/trajectory"/>
   <arg name="input/current_velocity" default="/localization/twist"/>
@@ -9,7 +8,6 @@
 
   <node pkg="pure_pursuit" exec="pure_pursuit" name="pure_pursuit" output="screen">
     <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
-    <param from="$(var vehicle_param_file)" />
     <remap from="input/reference_trajectory" to="$(var input/reference_trajectory)"/>
     <remap from="input/current_velocity" to="$(var input/current_velocity)"/>
     <remap from="output/control_raw" to="$(var output/control_raw)"/>

--- a/control/trajectory_follower/lane_departure_checker/launch/lane_departure_checker.launch.xml
+++ b/control/trajectory_follower/lane_departure_checker/launch/lane_departure_checker.launch.xml
@@ -4,7 +4,6 @@
   <arg name="input/route" default="/planning/mission_planning/route" />
   <arg name="input/reference_trajectory" default="/planning/scenario_planning/trajectory" />
   <arg name="input/predicted_trajectory" default="/control/trajectory_follower/predicted_trajectory" />
-  <arg name="vehicle_param_file"/>
   <arg name="config_file" default="$(find-pkg-share lane_departure_checker)/config/lane_departure_checker.param.yaml" />
 
   <node pkg="lane_departure_checker" exec="lane_departure_checker_node" name="lane_departure_checker_node" output="screen">
@@ -14,7 +13,6 @@
     <remap from="~/input/route" to="$(var input/route)"/>
     <remap from="~/input/reference_trajectory" to="$(var input/reference_trajectory)"/>
     <remap from="~/input/predicted_trajectory" to="$(var input/predicted_trajectory)"/>
-    <param from="$(var vehicle_param_file)" />
     <param from="$(var config_file)" />
   </node>
 </launch>

--- a/control/trajectory_follower/obstacle_collision_checker/launch/obstacle_collision_checker.launch.xml
+++ b/control/trajectory_follower/obstacle_collision_checker/launch/obstacle_collision_checker.launch.xml
@@ -5,11 +5,9 @@
   <arg name="input/predicted_trajectory" default="/control/trajectory_follower/predicted_trajectory" />
   <arg name="input/twist" default="/localization/twist" />
   <arg name="config_file" default="$(find-pkg-share obstacle_collision_checker)/config/obstacle_collision_checker.param.yaml" />
-  <arg name="vehicle_param_file" />
 
   <node pkg="obstacle_collision_checker" exec="obstacle_collision_checker_node" name="obstacle_collision_checker_node" output="screen">
     <param from="$(var config_file)" />
-    <param from="$(var vehicle_param_file)" />
     <remap from="input/lanelet_map_bin" to="$(var input/lanelet_map_bin)"/>
     <remap from="input/obstacle_pointcloud" to="$(var input/obstacle_pointcloud)"/>
     <remap from="input/reference_trajectory" to="$(var input/reference_trajectory)"/>

--- a/control/vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
+++ b/control/vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
@@ -1,12 +1,10 @@
 <launch>
-  <arg name="vehicle_param_file" />
   <arg name="config_file" default="$(find-pkg-share vehicle_cmd_gate)/config/vehicle_cmd_gate.param.yaml" />
   <arg name="use_emergency_handling" default="false" />
   <arg name="use_external_emergency_stop" default="true" />
 
   <node pkg="vehicle_cmd_gate" exec="vehicle_cmd_gate" name="vehicle_cmd_gate" output="screen">
     <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
-    <param from="$(var vehicle_param_file)" />
     <remap from="input/engage" to="/autoware/engage"/>
     <remap from="input/system_emergency" to="/system/emergency/is_emergency"/>
     <remap from="input/external_emergency_stop" to="/remote/emergency_stop"/>

--- a/control/velocity_controller/launch/velocity_controller.launch.xml
+++ b/control/velocity_controller/launch/velocity_controller.launch.xml
@@ -10,12 +10,10 @@
   <arg name="enable_pub_debug" default="true" />
 
   <arg name="velocity_controller_param_path" default="$(find-pkg-share velocity_controller)/config/velocity_controller.param.yaml" />
-  <arg name="vehicle_param_file"/>
 
   <node pkg="velocity_controller" exec="velocity_controller" name="velocity_controller" output="screen">
     <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var velocity_controller_param_path)"/>
-    <param from="$(var vehicle_param_file)"/>
 
     <remap from="~/current_velocity" to="/localization/twist"/>
     <remap from="~/control_cmd" to="longitudinal/control_cmd"/>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
@@ -16,7 +16,6 @@
   <arg name="max_accel" default="-2.8" />
   <arg name="delay_response_time" default="1.3" />
 
-  <arg name="vehicle_param_file" />
 
   <node pkg="behavior_velocity_planner" exec="behavior_velocity_planner_node" name="behavior_velocity_planner" output="screen">
     <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
@@ -26,7 +25,6 @@
     <param from="$(find-pkg-share behavior_velocity_planner)/config/intersection.param.yaml" />
     <param from="$(find-pkg-share behavior_velocity_planner)/config/stop_line.param.yaml" />
     <param from="$(find-pkg-share behavior_velocity_planner)/config/traffic_light.param.yaml" />
-    <param from="$(var vehicle_param_file)" />
 
     <remap from="~/input/path_with_lane_id" to="path_with_lane_id" />
     <remap from="~/input/vector_map" to="$(var map_topic_name)" />

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/launch/obstacle_avoidance_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/launch/obstacle_avoidance_planner.launch.xml
@@ -5,7 +5,6 @@
   <arg name="is_showing_debug_info" default="false"/>
   <arg name="is_stopping_if_outside_drivable_area" default="true"/>
   <arg name="param_path" default="$(find-pkg-share obstacle_avoidance_planner)/config/obstacle_avoidance_planner.param.yaml" />
-  <arg name="vehicle_param_file" default="$(find-pkg-share lexus_description)/config/vehicle_info.param.yaml" />
 
   <node pkg="obstacle_avoidance_planner" exec="obstacle_avoidance_planner_node"
     name="obstacle_avoidance_planner" output="screen">
@@ -15,7 +14,6 @@
     <remap from="~/output/path" to="$(var output_path_topic)" />
 
     <param from="$(var param_path)" />
-    <param from="$(var vehicle_param_file)" />
     <param name="is_showing_debug_info" value="$(var is_showing_debug_info)"/>
     <param name="is_stopping_if_outside_drivable_area" value="$(var is_stopping_if_outside_drivable_area)"/>
   </node>

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
@@ -7,11 +7,9 @@
   <arg name="enable_slow_down" default="false" />
   <arg name="param_file" default="$(find-pkg-share obstacle_stop_planner)/config/obstacle_stop_planner.param.yaml" />
   <arg name="acc_param_file" default="$(find-pkg-share obstacle_stop_planner)/config/adaptive_cruise_control.param.yaml" />
-  <arg name="vehicle_param_file"/>
 
   <node pkg="obstacle_stop_planner" exec="obstacle_stop_planner_node" name="obstacle_stop_planner" output="screen">
     <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
-    <param from="$(var vehicle_param_file)" />
     <param from="$(var acc_param_file)" />
     <param from="$(var param_file)" />
     <remap from="~/output/stop_reason" to="/planning/scenario_planning/status/stop_reason" />

--- a/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
@@ -1,6 +1,5 @@
 <launch>
   <arg name="param_path" default="$(find-pkg-share surround_obstacle_checker)/config/surround_obstacle_checker.param.yaml" />
-  <arg name="vehicle_param_file" default="$(find-pkg-share lexus_description)/config/vehicle_info.param.yaml" />
 
   <arg name="input_trajectory" default="input/trajectory" />
   <arg name="input_objects" default="/perception/object_recognition/objects" />
@@ -11,7 +10,6 @@
   <node pkg="surround_obstacle_checker" exec="surround_obstacle_checker_node" name="surround_obstacle_checker" output="screen">
     <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var param_path)" />
-    <param from="$(var vehicle_param_file)" />
     <remap from="~/output/no_start_reason" to="/planning/scenario_planning/status/no_start_reason" />
     <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons" />
     <remap from="~/output/trajectory" to="$(var output_trajectory)" />

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -45,10 +45,6 @@ def generate_launch_description():
         default_value=simple_planning_simulator_param_file,
         description='Path to config file for simple_planning_simulator'
     )
-    vehicle_param_file_param = DeclareLaunchArgument(
-        'vehicle_param_file',
-        description='Path to config file for vehicle param'
-    )
 
     simple_planning_simulator = Node(
         package='simple_planning_simulator',
@@ -58,7 +54,6 @@ def generate_launch_description():
         output='screen',
         parameters=[
             LaunchConfiguration('simple_planning_simulator_param_file'),
-            LaunchConfiguration('vehicle_param_file'),
         ],
         remappings=[
             ('base_trajectory', '/planning/scenario_planning/trajectory'),
@@ -76,6 +71,5 @@ def generate_launch_description():
 
     return LaunchDescription([
         simple_planning_simulator_param,
-        vehicle_param_file_param,
         simple_planning_simulator
     ])

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.xml
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.xml
@@ -9,7 +9,6 @@
 
   <!-- model parameters -->
   <arg name="simulator_model" default="$(find-pkg-share simple_planning_simulator)/config/simple_planning_simulator.param.yaml"/>
-  <arg name="vehicle_param_file"/>
 
   <!-- simple_planning_simulator node -->
   <node pkg="simple_planning_simulator" exec="simple_planning_simulator_exe" name="simple_planning_simulator" output="screen">
@@ -26,7 +25,6 @@
     <remap from="input/engage" to="/vehicle/engage" />
 
     <param from="$(var simulator_model)"/>
-    <param from="$(var vehicle_param_file)"/>
 
     <param name="loop_rate" value="$(var loop_rate)"/>
     <param name="simulation_frame_id" value="$(var simulation_frame_id)"/>

--- a/vehicle/as/launch/pacmod_interface.launch.xml
+++ b/vehicle/as/launch/pacmod_interface.launch.xml
@@ -3,12 +3,10 @@
 
   <arg name="pacmod_param_path" default="$(find-pkg-share as)/config/pacmod.param.yaml"/>
 
-  <arg name="vehicle_param_file" default="$(find-pkg-share lexus_description)/config/vehicle_info.param.yaml" />
 
   <!-- pacmod interface -->
   <node pkg="as" exec="pacmod_interface" name="pacmod_interface" output="screen">
     <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
-    <param from="$(var vehicle_param_file)" />
     <param from="$(var pacmod_param_path)" />
   </node>
 

--- a/vehicle/util/vehicle_info_util/include/vehicle_info_util/vehicle_info.hpp
+++ b/vehicle/util/vehicle_info_util/include/vehicle_info_util/vehicle_info.hpp
@@ -72,6 +72,9 @@ private:
   // Used to check if parameters are already declared or not in order to avoid
   // declaring parameters multiple times.
   static bool parametersAlreadyDeclared(rclcpp::Node & node);
+  static void declearVehicleParameters(rclcpp::Node & node);
+  static VehicleInfo getVehicleInfo(rclcpp::Node & node);
+  static void waitVehicleInfo(rclcpp::Node & node);
 };
 
 }  // namespace vehicle_info_util

--- a/vehicle/util/vehicle_info_util/src/vehicle_info.cpp
+++ b/vehicle/util/vehicle_info_util/src/vehicle_info.cpp
@@ -94,6 +94,7 @@ void VehicleInfo::waitVehicleInfo(rclcpp::Node & node)
   while (rclcpp::ok() && !node.get_parameter("ready_vehicle_info_param").as_bool()) {
     RCLCPP_INFO_STREAM_THROTTLE(
       node.get_logger(), *node.get_clock(), 5000 /* ms */, "wait for vehicle info");
+    rclcpp::spin_some(node.get_node_base_interface());
     rclcpp::Rate(100.0).sleep();
   }
 }

--- a/vehicle/util/vehicle_info_util/src/vehicle_info.cpp
+++ b/vehicle/util/vehicle_info_util/src/vehicle_info.cpp
@@ -44,48 +44,68 @@ VehicleInfo::VehicleInfo(
 
 bool VehicleInfo::parametersAlreadyDeclared(rclcpp::Node & node)
 {
-  return
-    node.has_parameter("wheel_radius") &&
-    node.has_parameter("wheel_width") &&
-    node.has_parameter("wheel_base") &&
-    node.has_parameter("wheel_tread") &&
-    node.has_parameter("front_overhang") &&
-    node.has_parameter("rear_overhang") &&
-    node.has_parameter("left_overhang") &&
-    node.has_parameter("right_overhang") &&
-    node.has_parameter("vehicle_height")
-  ;
+  return node.has_parameter("wheel_radius") && node.has_parameter("wheel_width") &&
+         node.has_parameter("wheel_base") && node.has_parameter("wheel_tread") &&
+         node.has_parameter("front_overhang") && node.has_parameter("rear_overhang") &&
+         node.has_parameter("left_overhang") && node.has_parameter("right_overhang") &&
+         node.has_parameter("vehicle_height");
+}
+
+void VehicleInfo::declearVehicleParameters(rclcpp::Node & node)
+{
+  /*
+  Node:
+   By setting allow_undeclared_parameters to true,
+   it becomes posiible to declare prameter without default value, and
+   wait parameters by this->get_parameter().get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET.
+   But from a code safety point of view, do not do it.
+  */
+
+  node.declare_parameter("wheel_radius", 0.0);
+  node.declare_parameter("wheel_width", 0.0);
+  node.declare_parameter("wheel_base", 0.0);
+  node.declare_parameter("wheel_tread", 0.0);
+  node.declare_parameter("front_overhang", 0.0);
+  node.declare_parameter("rear_overhang", 0.0);
+  node.declare_parameter("left_overhang", 0.0);
+  node.declare_parameter("right_overhang", 0.0);
+  node.declare_parameter("vehicle_height", 0.0);
+  node.declare_parameter("ready_vehicle_info_param", false);
+}
+
+VehicleInfo VehicleInfo::getVehicleInfo(rclcpp::Node & node)
+{
+  const double wheel_radius_m = node.get_parameter("wheel_radius").as_double();
+  const double wheel_width_m = node.get_parameter("wheel_width").as_double();
+  const double wheel_base_m = node.get_parameter("wheel_base").as_double();
+  const double wheel_tread_m = node.get_parameter("wheel_tread").as_double();
+  const double front_overhang_m = node.get_parameter("front_overhang").as_double();
+  const double rear_overhang_m = node.get_parameter("rear_overhang").as_double();
+  const double left_overhang_m = node.get_parameter("left_overhang").as_double();
+  const double right_overhang_m = node.get_parameter("right_overhang").as_double();
+  const double vehicle_height_m = node.get_parameter("vehicle_height").as_double();
+  return VehicleInfo(
+    wheel_radius_m, wheel_width_m, wheel_base_m, wheel_tread_m, front_overhang_m, rear_overhang_m,
+    left_overhang_m, right_overhang_m, vehicle_height_m);
+}
+
+void VehicleInfo::waitVehicleInfo(rclcpp::Node & node)
+{
+  while (rclcpp::ok() && !node.get_parameter("ready_vehicle_info_param").as_bool()) {
+    RCLCPP_INFO_STREAM_THROTTLE(
+      node.get_logger(), *node.get_clock(), 5000 /* ms */, "wait for vehicle info");
+    rclcpp::Rate(100.0).sleep();
+  }
 }
 
 VehicleInfo VehicleInfo::create(rclcpp::Node & node)
 {
   if (!parametersAlreadyDeclared(node)) {
-    const double wheel_radius_m = node.declare_parameter("wheel_radius").get<double>();
-    const double wheel_width_m = node.declare_parameter("wheel_width").get<double>();
-    const double wheel_base_m = node.declare_parameter("wheel_base").get<double>();
-    const double wheel_tread_m = node.declare_parameter("wheel_tread").get<double>();
-    const double front_overhang_m = node.declare_parameter("front_overhang").get<double>();
-    const double rear_overhang_m = node.declare_parameter("rear_overhang").get<double>();
-    const double left_overhang_m = node.declare_parameter("left_overhang").get<double>();
-    const double right_overhang_m = node.declare_parameter("right_overhang").get<double>();
-    const double vehicle_height_m = node.declare_parameter("vehicle_height").get<double>();
-    return VehicleInfo(
-      wheel_radius_m, wheel_width_m, wheel_base_m, wheel_tread_m, front_overhang_m, rear_overhang_m,
-      left_overhang_m, right_overhang_m, vehicle_height_m);
-  } else {
-    const double wheel_radius_m = node.get_parameter("wheel_radius").as_double();
-    const double wheel_width_m = node.get_parameter("wheel_width").as_double();
-    const double wheel_base_m = node.get_parameter("wheel_base").as_double();
-    const double wheel_tread_m = node.get_parameter("wheel_tread").as_double();
-    const double front_overhang_m = node.get_parameter("front_overhang").as_double();
-    const double rear_overhang_m = node.get_parameter("rear_overhang").as_double();
-    const double left_overhang_m = node.get_parameter("left_overhang").as_double();
-    const double right_overhang_m = node.get_parameter("right_overhang").as_double();
-    const double vehicle_height_m = node.get_parameter("vehicle_height").as_double();
-    return VehicleInfo(
-      wheel_radius_m, wheel_width_m, wheel_base_m, wheel_tread_m, front_overhang_m, rear_overhang_m,
-      left_overhang_m, right_overhang_m, vehicle_height_m);
+    declearVehicleParameters(node);
+    waitVehicleInfo(node);
   }
+
+  return getVehicleInfo(node);
 }
 
 }  // namespace vehicle_info_util

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/CMakeLists.txt
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.5)
+project(vehicle_info_param_server)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic -Werror)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+ament_auto_add_executable(vehicle_info_param_server
+  src/vehicle_info_param_server_node.cpp
+  src/vehicle_info_param_server_core.cpp
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package(INSTALL_TO_SHARE launch)

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/include/vehicle_info_param_server/vehicle_info_param_server_core.hpp
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/include/vehicle_info_param_server/vehicle_info_param_server_core.hpp
@@ -55,9 +55,11 @@ private:
     std::vector<rclcpp::Parameter> params)
   {
     auto set_parameters_results = client->set_parameters(params);
-    return rclcpp::spin_until_future_complete(
-      this->get_node_base_interface(), set_parameters_results) ==
-           rclcpp::executor::FutureReturnCode::SUCCESS &&
+    const auto timeout_chrono = std::chrono::duration<double>(timeout);
+    using rclcpp::spin_until_future_complete;
+    return spin_until_future_complete(
+      this->get_node_base_interface(), set_parameters_results, timeout_chrono) ==
+           rclcpp::FutureReturnCode::SUCCESS ||
            set_parameters_results.get().front().successful;
   }
 
@@ -87,7 +89,7 @@ private:
 
   rclcpp::TimerBase::SharedPtr timer_;
   std::vector<rclcpp::Parameter> vehicle_info_params;
-  double request_timeout_sec_ = 0.1;
+  double request_timeout_sec_ = 0.2;
 };
 
 #endif  // VEHICLE_INFO_PARAM_SERVER__VEHICLE_INFO_PARAM_SERVER_CORE_HPP_

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/include/vehicle_info_param_server/vehicle_info_param_server_core.hpp
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/include/vehicle_info_param_server/vehicle_info_param_server_core.hpp
@@ -89,6 +89,7 @@ private:
 
   rclcpp::TimerBase::SharedPtr timer_;
   std::vector<rclcpp::Parameter> vehicle_info_params;
+  std::vector<std::string> set_node_list_;
   double request_timeout_sec_ = 0.2;
 };
 

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/include/vehicle_info_param_server/vehicle_info_param_server_core.hpp
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/include/vehicle_info_param_server/vehicle_info_param_server_core.hpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+#include <vector>
+
 #include "rclcpp/rclcpp.hpp"
 
 #ifndef VEHICLE_INFO_PARAM_SERVER__VEHICLE_INFO_PARAM_SERVER_CORE_HPP_
@@ -36,7 +39,8 @@ private:
     using rclcpp::spin_until_future_complete;
     if (
       spin_until_future_complete(this->get_node_base_interface(), list_param, timeout_chrono) ==
-      rclcpp::FutureReturnCode::SUCCESS) {
+      rclcpp::FutureReturnCode::SUCCESS)
+    {
       auto vars = list_param.get();
       *result = vars.names.size() > 0;
       return true;
@@ -44,7 +48,7 @@ private:
     // timeout
     RCLCPP_DEBUG(get_logger(), "Timeout: hasParameter()");
     return false;
-  };
+  }
 
   bool setParameter(
     const rclcpp::AsyncParametersClient::SharedPtr client, const double timeout,
@@ -52,12 +56,12 @@ private:
   {
     auto set_parameters_results = client->set_parameters(params);
     return rclcpp::spin_until_future_complete(
-             this->get_node_base_interface(), set_parameters_results) ==
-             rclcpp::executor::FutureReturnCode::SUCCESS &&
+      this->get_node_base_interface(), set_parameters_results) ==
+           rclcpp::executor::FutureReturnCode::SUCCESS &&
            set_parameters_results.get().front().successful;
-  };
+  }
 
-  template <class T>
+  template<class T>
   bool getParameter(
     const rclcpp::AsyncParametersClient::SharedPtr client, const std::string & param_name,
     const double timeout, T * result)
@@ -70,7 +74,8 @@ private:
     using rclcpp::spin_until_future_complete;
     if (
       spin_until_future_complete(this->get_node_base_interface(), get_param, timeout_chrono) ==
-      rclcpp::FutureReturnCode::SUCCESS) {
+      rclcpp::FutureReturnCode::SUCCESS)
+    {
       auto vars = get_param.get();
       *result = vars.front().get_value<T>();
       return true;

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/include/vehicle_info_param_server/vehicle_info_param_server_core.hpp
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/include/vehicle_info_param_server/vehicle_info_param_server_core.hpp
@@ -1,0 +1,88 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/rclcpp.hpp"
+
+#ifndef VEHICLE_INFO_PARAM_SERVER__VEHICLE_INFO_PARAM_SERVER_CORE_HPP_
+#define VEHICLE_INFO_PARAM_SERVER__VEHICLE_INFO_PARAM_SERVER_CORE_HPP_
+
+class VehicleInfoParamServer : public rclcpp::Node
+{
+public:
+  VehicleInfoParamServer();
+
+private:
+  void setVehicleInfoParameters();
+  bool hasParameter(
+    const rclcpp::AsyncParametersClient::SharedPtr client, const std::string & param_name,
+    const double timeout, bool * result)
+  {
+    std::vector<std::string> params;
+    params.emplace_back(param_name);
+    auto list_param = client->list_parameters(params, 1);
+
+    const auto timeout_chrono = std::chrono::duration<double>(timeout);
+    using rclcpp::spin_until_future_complete;
+    if (
+      spin_until_future_complete(this->get_node_base_interface(), list_param, timeout_chrono) ==
+      rclcpp::FutureReturnCode::SUCCESS) {
+      auto vars = list_param.get();
+      *result = vars.names.size() > 0;
+      return true;
+    }
+    // timeout
+    RCLCPP_DEBUG(get_logger(), "Timeout: hasParameter()");
+    return false;
+  };
+
+  bool setParameter(
+    const rclcpp::AsyncParametersClient::SharedPtr client, const double timeout,
+    std::vector<rclcpp::Parameter> params)
+  {
+    auto set_parameters_results = client->set_parameters(params);
+    return rclcpp::spin_until_future_complete(
+             this->get_node_base_interface(), set_parameters_results) ==
+             rclcpp::executor::FutureReturnCode::SUCCESS &&
+           set_parameters_results.get().front().successful;
+  };
+
+  template <class T>
+  bool getParameter(
+    const rclcpp::AsyncParametersClient::SharedPtr client, const std::string & param_name,
+    const double timeout, T * result)
+  {
+    std::vector<std::string> params;
+    params.emplace_back(param_name);
+    auto get_param = client->get_parameters(params);
+
+    const auto timeout_chrono = std::chrono::duration<double>(timeout);
+    using rclcpp::spin_until_future_complete;
+    if (
+      spin_until_future_complete(this->get_node_base_interface(), get_param, timeout_chrono) ==
+      rclcpp::FutureReturnCode::SUCCESS) {
+      auto vars = get_param.get();
+      *result = vars.front().get_value<T>();
+      return true;
+    }
+    // timeout
+    RCLCPP_DEBUG(get_logger(), "Timeout: getParameter()");
+    return false;
+  }
+
+  rclcpp::TimerBase::SharedPtr timer_;
+  std::vector<rclcpp::Parameter> vehicle_info_params;
+  double request_timeout_sec_ = 0.1;
+};
+
+#endif  // VEHICLE_INFO_PARAM_SERVER__VEHICLE_INFO_PARAM_SERVER_CORE_HPP_

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/launch/vehicle_info_param_server.launch.xml
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/launch/vehicle_info_param_server.launch.xml
@@ -1,7 +1,10 @@
 <launch>
 
+    <arg name="config_file" />
+
     <node pkg="vehicle_info_param_server" exec="vehicle_info_param_server" name="vehicle_info_param_server" output="log">
         <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
+        <param from="$(var config_file)"/>
     </node>
 
 </launch>

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/launch/vehicle_info_param_server.launch.xml
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/launch/vehicle_info_param_server.launch.xml
@@ -1,0 +1,7 @@
+<launch>
+
+    <node pkg="vehicle_info_param_server" exec="vehicle_info_param_server" name="vehicle_info_param_server" output="log">
+        <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
+    </node>
+
+</launch>

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/package.xml
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>vehicle_info_param_server</name>
+  <version>0.1.0</version>
+  <description>The vehicle_info_param_server package</description>
+  <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
+  <author email="tomoya.kimura@tier4.jp">Tomoya Kimura</author>
+  <license>BSD</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>rclcpp</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_core.cpp
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_core.cpp
@@ -1,0 +1,97 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "vehicle_info_param_server/vehicle_info_param_server_core.hpp"
+
+VehicleInfoParamServer::VehicleInfoParamServer() : Node("vehicle_info_param_server")
+{
+  const double wheel_radius_m = this->declare_parameter("wheel_radius").get<double>();
+  const double wheel_width_m = this->declare_parameter("wheel_width").get<double>();
+  const double wheel_base_m = this->declare_parameter("wheel_base").get<double>();
+  const double wheel_tread_m = this->declare_parameter("wheel_tread").get<double>();
+  const double front_overhang_m = this->declare_parameter("front_overhang").get<double>();
+  const double rear_overhang_m = this->declare_parameter("rear_overhang").get<double>();
+  const double left_overhang_m = this->declare_parameter("left_overhang").get<double>();
+  const double right_overhang_m = this->declare_parameter("right_overhang").get<double>();
+  const double vehicle_height_m = this->declare_parameter("vehicle_height").get<double>();
+
+  // create vehicle_info_params
+  vehicle_info_params.emplace_back(rclcpp::Parameter("wheel_radius", wheel_radius_m));
+  vehicle_info_params.emplace_back(rclcpp::Parameter("wheel_width", wheel_width_m));
+  vehicle_info_params.emplace_back(rclcpp::Parameter("wheel_base", wheel_base_m));
+  vehicle_info_params.emplace_back(rclcpp::Parameter("wheel_tread", wheel_tread_m));
+  vehicle_info_params.emplace_back(rclcpp::Parameter("front_overhang", front_overhang_m));
+  vehicle_info_params.emplace_back(rclcpp::Parameter("rear_overhang", rear_overhang_m));
+  vehicle_info_params.emplace_back(rclcpp::Parameter("left_overhang", left_overhang_m));
+  vehicle_info_params.emplace_back(rclcpp::Parameter("right_overhang", right_overhang_m));
+  vehicle_info_params.emplace_back(rclcpp::Parameter("vehicle_height", vehicle_height_m));
+  vehicle_info_params.emplace_back(rclcpp::Parameter("ready_vehicle_info_param", true));
+
+  // timer
+  auto timer_callback = std::bind(&VehicleInfoParamServer::setVehicleInfoParameters, this);
+  auto period =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(1.0));
+  timer_ = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
+    this->get_clock(), period, std::move(timer_callback),
+    this->get_node_base_interface()->get_context());
+  this->get_node_timers_interface()->add_timer(timer_, nullptr);
+}
+
+void VehicleInfoParamServer::setVehicleInfoParameters()
+{
+  std::vector<std::string> node_names = get_node_names();
+
+  for (const auto & n : node_names) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(this->get_logger(), "Interrupted while waiting for the service. Exiting.");
+      break;
+    }
+
+    // wait for parameter service
+    auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(this, n);
+    using namespace std::chrono_literals;
+    if (!parameters_client->wait_for_service(100ms)) {
+      // cannot access to parameter service
+      continue;
+    }
+
+    // Check that the node has vehicle_info client or not
+    bool has_param;
+    if (
+      !hasParameter(
+        parameters_client, "ready_vehicle_info_param", request_timeout_sec_, &has_param) ||
+      !has_param) {
+      // No need to set vehicle parameter.
+      continue;
+    }
+
+    // Check that the vehicle_info_params are already set to the node or not.
+    bool ready_vehicle_info_param;
+    if (
+      !getParameter<bool>(
+        parameters_client, "ready_vehicle_info_param", request_timeout_sec_,
+        &ready_vehicle_info_param) ||
+      ready_vehicle_info_param) {
+      // Already vehicle_info_params are already set.
+      continue;
+    }
+
+    // Set Parameter
+    while (!setParameter(parameters_client, request_timeout_sec_, vehicle_info_params)) {
+      rclcpp::Rate(100.0).sleep();
+    }
+
+    RCLCPP_INFO_STREAM(get_logger(), "Set vehicle_info_param: " << n);
+  }
+}

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_core.cpp
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_core.cpp
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "vehicle_info_param_server/vehicle_info_param_server_core.hpp"
 
-VehicleInfoParamServer::VehicleInfoParamServer() : Node("vehicle_info_param_server")
+VehicleInfoParamServer::VehicleInfoParamServer()
+: Node("vehicle_info_param_server")
 {
   const double wheel_radius_m = this->declare_parameter("wheel_radius").get<double>();
   const double wheel_width_m = this->declare_parameter("wheel_width").get<double>();
@@ -71,7 +77,8 @@ void VehicleInfoParamServer::setVehicleInfoParameters()
     if (
       !hasParameter(
         parameters_client, "ready_vehicle_info_param", request_timeout_sec_, &has_param) ||
-      !has_param) {
+      !has_param)
+    {
       // No need to set vehicle parameter.
       continue;
     }
@@ -82,7 +89,8 @@ void VehicleInfoParamServer::setVehicleInfoParameters()
       !getParameter<bool>(
         parameters_client, "ready_vehicle_info_param", request_timeout_sec_,
         &ready_vehicle_info_param) ||
-      ready_vehicle_info_param) {
+      ready_vehicle_info_param)
+    {
       // Already vehicle_info_params are already set.
       continue;
     }

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_core.cpp
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_core.cpp
@@ -55,15 +55,16 @@ void VehicleInfoParamServer::setVehicleInfoParameters()
 {
   std::vector<std::string> node_names = get_node_names();
 
+  // remove self node
+  node_names.erase(
+    std::remove_if(
+      node_names.begin(), node_names.end(),
+      [](std::string s) {
+        return s.find(std::string("vehicle_info_param_server")) != std::string::npos;
+      }),
+    node_names.end());
+
   for (const auto & n : node_names) {
-
-    // remove self node
-    node_names.erase(
-      std::remove_if(
-        node_names.begin(), node_names.end(),
-        [](std::string s) {return s.find(std::string("vehicle_info_param_server")) != std::string::npos;}),
-      node_names.end());
-
     // remove nodes that already checked
     if (std::find(set_node_list_.begin(), set_node_list_.end(), n) != set_node_list_.end()) {
       continue;
@@ -90,7 +91,7 @@ void VehicleInfoParamServer::setVehicleInfoParameters()
       !has_param)
     {
       // No need to set vehicle parameter.
-      if(has_param) set_node_list_.emplace_back(n);
+      if (has_param) {set_node_list_.emplace_back(n);}
       continue;
     }
 
@@ -103,7 +104,7 @@ void VehicleInfoParamServer::setVehicleInfoParameters()
       ready_vehicle_info_param)
     {
       // Already vehicle_info_params are already set.
-      if(ready_vehicle_info_param) set_node_list_.emplace_back(n);
+      if (ready_vehicle_info_param) {set_node_list_.emplace_back(n);}
       continue;
     }
 
@@ -111,7 +112,7 @@ void VehicleInfoParamServer::setVehicleInfoParameters()
     while (!setParameter(parameters_client, request_timeout_sec_, vehicle_info_params)) {
       rclcpp::Rate(100.0).sleep();
     }
-      set_node_list_.emplace_back(n);
-      RCLCPP_INFO_STREAM(this->get_logger(), "Set vehicle info parameter: " << n);
+    set_node_list_.emplace_back(n);
+    RCLCPP_INFO_STREAM(this->get_logger(), "Set vehicle info parameter: " << n);
   }
 }

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_core.cpp
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_core.cpp
@@ -45,13 +45,10 @@ VehicleInfoParamServer::VehicleInfoParamServer()
   vehicle_info_params.emplace_back(rclcpp::Parameter("ready_vehicle_info_param", true));
 
   // timer
-  auto timer_callback = std::bind(&VehicleInfoParamServer::setVehicleInfoParameters, this);
-  auto period =
-    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(1.0));
-  timer_ = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
-    this->get_clock(), period, std::move(timer_callback),
-    this->get_node_base_interface()->get_context());
-  this->get_node_timers_interface()->add_timer(timer_, nullptr);
+  while (rclcpp::ok()) {
+    setVehicleInfoParameters();
+    rclcpp::Rate(10.0).sleep();
+  }
 }
 
 void VehicleInfoParamServer::setVehicleInfoParameters()
@@ -59,6 +56,9 @@ void VehicleInfoParamServer::setVehicleInfoParameters()
   std::vector<std::string> node_names = get_node_names();
 
   for (const auto & n : node_names) {
+    // remove self node
+    // remove the node that already checked
+
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(this->get_logger(), "Interrupted while waiting for the service. Exiting.");
       break;
@@ -100,6 +100,5 @@ void VehicleInfoParamServer::setVehicleInfoParameters()
       rclcpp::Rate(100.0).sleep();
     }
 
-    RCLCPP_INFO_STREAM(get_logger(), "Set vehicle_info_param: " << n);
   }
 }

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_node.cpp
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_node.cpp
@@ -1,0 +1,26 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "vehicle_info_param_server/vehicle_info_param_server_core.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<VehicleInfoParamServer>());
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_node.cpp
+++ b/vehicle/vehicle_description/util/vehicle_info_param_server/src/vehicle_info_param_server_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+
 #include "rclcpp/rclcpp.hpp"
 
 #include "vehicle_info_param_server/vehicle_info_param_server_core.hpp"


### PR DESCRIPTION
Add vehicle_info_param_server.
- vehicle_info_param_server node sets rosparameter for all necessary nodes.
- Delete unnecessary vehicle_param_file parameter described in Launch files.

## How to check (with https://github.com/tier4/autoware_launcher.iv.universe/pull/96 )

```
$ros2 launch autoware_launch planning_simulator.launch.xml vehicle_model:=lexus vehicle_id:=default sensor_model:=aip_xx1 map_path:=MAP_PATH
```
- Set initial_pose and goal_pose
- publish autoware/engage and check that the vehicle works normally.