### PR TITLE
Ros2 fix service name

### DIFF
--- a/control/vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
+++ b/control/vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
@@ -31,8 +31,8 @@
     <remap from="output/turn_signal_cmd" to="/control/turn_signal_cmd"/>
     <remap from="output/gate_mode" to="/control/current_gate_mode"/>
 
-    <remap from="service/external_emergency_stop" to="external_emergency_stop"/>
-    <remap from="service/clear_external_emergency_stop" to="clear_external_emergency_stop"/>
+    <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
+    <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
 
     <param from="$(var config_file)" />
     <param name="use_emergency_handling" value="$(var use_emergency_handling)" />

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -138,7 +138,7 @@ VehicleCmdGate::VehicleCmdGate()
   srv_external_emergency_stop_ = this->create_service<std_srvs::srv::Trigger>(
     "~/service/external_emergency_stop",
     std::bind(&VehicleCmdGate::onExternalEmergencyStopService, this, _1, _2, _3));
-  srv_external_emergency_stop_ = this->create_service<std_srvs::srv::Trigger>(
+  srv_clear_external_emergency_stop_ = this->create_service<std_srvs::srv::Trigger>(
     "~/service/clear_external_emergency_stop",
     std::bind(&VehicleCmdGate::onClearExternalEmergencyStopService, this, _1, _2, _3));
 

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -136,10 +136,10 @@ VehicleCmdGate::VehicleCmdGate()
   using std::placeholders::_2;
   using std::placeholders::_3;
   srv_external_emergency_stop_ = this->create_service<std_srvs::srv::Trigger>(
-    "service/external_emergency_stop",
+    "~/service/external_emergency_stop",
     std::bind(&VehicleCmdGate::onExternalEmergencyStopService, this, _1, _2, _3));
   srv_external_emergency_stop_ = this->create_service<std_srvs::srv::Trigger>(
-    "service/clear_external_emergency_stop",
+    "~/service/clear_external_emergency_stop",
     std::bind(&VehicleCmdGate::onClearExternalEmergencyStopService, this, _1, _2, _3));
 
   // Diagnostics Updater


### PR DESCRIPTION
### How to test
- launch vehicle cmd gate
`ros2 launch vehicle_cmd_gate vehicle_cmd_gate.launch.xml vehicle_param_file:=/home/daisuke/workspace/AutowareArchitectureProposal/src/description/vehicle/lexus_description/config/vehicle_info.param.yaml`
- check service name
```
❯ ros2 service list
/vehicle_cmd_gate/clear_external_emergency_stop
/vehicle_cmd_gate/describe_parameters
/vehicle_cmd_gate/external_emergency_stop
/vehicle_cmd_gate/get_parameter_types
/vehicle_cmd_gate/get_parameters
/vehicle_cmd_gate/list_parameters
/vehicle_cmd_gate/set_parameters
/vehicle_cmd_gate/set_parameters_atomically
```
