### PR TITLE
add config files of plotjuggler

### DIFF
--- a/control/mpc_follower/config/plot_juggler_mpc_follower.xml
+++ b/control/mpc_follower/config/plot_juggler_mpc_follower.xml
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<root version="2.3.8">
+ <tabbed_widget parent="main_window" name="Main Window">
+  <Tab tab_name="MPC Follower" containers="1">
+   <Container>
+    <DockSplitter orientation="-" count="1" sizes="1">
+     <DockSplitter orientation="-" count="2" sizes="0.500772;0.499228">
+      <DockSplitter orientation="|" count="3" sizes="0.333333;0.333333;0.333333">
+       <DockArea name="mpc info">
+        <plot mode="TimeSeries" style="Lines">
+         <range left="130.024005" top="0.061687" bottom="-0.315669" right="195.287438"/>
+         <limitY/>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.5" color="#1f77b4">
+          <transform alias="lateral error" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.8" color="#d62728">
+          <transform alias="yaw error" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.0" color="#1ac938">
+          <transform alias="steer cmd" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.2" color="#ff7f0e">
+          <transform alias="steer cmd (FF-filtered)" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.3" color="#f14cc1">
+          <transform alias="steer cmd (FF-raw)" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.4" color="#9467bd">
+          <transform alias="steer measured" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.1" color="#17becf">
+          <transform alias="mpc steer raw" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+        </plot>
+       </DockArea>
+       <DockArea name="velocity">
+        <plot mode="TimeSeries" style="Lines">
+         <range left="130.024005" top="0.256250" bottom="-0.006250" right="195.287438"/>
+         <limitY/>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.9" color="#1f77b4">
+          <transform alias="trajectory velocity" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.10" color="#d62728">
+          <transform alias="current velocity" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+        </plot>
+       </DockArea>
+       <DockArea name="path curvature">
+        <plot mode="TimeSeries" style="Lines">
+         <range left="130.024005" top="0.073564" bottom="0.015337" right="195.287438"/>
+         <limitY/>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.14" color="#d62728">
+          <transform alias="smoothed" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.16" color="#1f77b4">
+          <transform alias="raw" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter orientation="|" count="3" sizes="0.333333;0.333333;0.333333">
+       <DockArea name="mpc info(angvel)">
+        <plot mode="TimeSeries" style="Lines">
+         <range left="130.023079" top="1.025000" bottom="-0.025000" right="195.291189"/>
+         <limitY/>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.11" color="#1ac938">
+          <transform alias="steering cmd" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.12" color="#ff7f0e">
+          <transform alias="measured steer" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.13" color="#d62728">
+          <transform alias="path curvature" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.17" color="#1f77b4">
+          <transform alias="steer prediction" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/vehicle/status/control_mode/data" color="#f14cc1">
+          <transform alias="control mode" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+        </plot>
+       </DockArea>
+       <DockArea name="yaw">
+        <plot mode="TimeSeries" style="Lines">
+         <range left="130.024005" top="0.517228" bottom="0.472266" right="195.287438"/>
+         <limitY/>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.7" color="#1ac938">
+          <transform alias="desired yaw" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+         <curve name="/control/trajectory_follower/mpc_follower/debug/debug_values/data.6" color="#ff7f0e">
+          <transform alias="current yaw" name="Scale/Offset">
+           <options value_offset="0" value_scale="1.0" time_offset="0"/>
+          </transform>
+         </curve>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot mode="TimeSeries" style="Lines">
+         <range left="0.000000" top="1.000000" bottom="0.000000" right="1.000000"/>
+         <limitY/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+     </DockSplitter>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <currentTabIndex index="0"/>
+ </tabbed_widget>
+ <use_relative_time_offset enabled="1"/>
+ <!-- - - - - - - - - - - - - - - -->
+ <!-- - - - - - - - - - - - - - - -->
+ <Plugins>
+  <plugin ID="DataLoad CSV">
+   <default time_axis=""/>
+  </plugin>
+  <plugin ID="DataLoad ROS2 bags">
+   <use_header_stamp value="false"/>
+   <discard_large_arrays value="true"/>
+   <max_array_size value="100"/>
+  </plugin>
+  <plugin ID="DataLoad ULog"/>
+  <plugin ID="MQTT Subscriber"/>
+  <plugin ID="ROS2 Topic Subscriber">
+   <use_header_stamp value="false"/>
+   <discard_large_arrays value="false"/>
+   <max_array_size value="true"/>
+   <selected_topics>
+    <topic name="/control/trajectory_follower/mpc_follower/debug/debug_values"/>
+    <topic name="/vehicle/status/control_mode"/>
+   </selected_topics>
+  </plugin>
+  <plugin ID="UDP Server"/>
+  <plugin ID="WebSocket Server"/>
+  <plugin ID="ZMQ Subscriber"/>
+  <plugin status="idle" ID="ROS2 Topic Re-Publisher"/>
+ </Plugins>
+ <!-- - - - - - - - - - - - - - - -->
+ <previouslyLoaded_Datafiles/>
+ <previouslyLoaded_Streamer name="ROS2 Topic Subscriber"/>
+ <!-- - - - - - - - - - - - - - - -->
+ <customMathEquations/>
+ <snippets/>
+ <!-- - - - - - - - - - - - - - - -->
+</root>
+

--- a/control/velocity_controller/config/plot_juggler_velocity_controller.xml
+++ b/control/velocity_controller/config/plot_juggler_velocity_controller.xml
@@ -1,0 +1,174 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<root version="2.3.8">
+ <tabbed_widget name="Main Window" parent="main_window">
+  <Tab containers="1" tab_name="tab1">
+   <Container>
+    <DockSplitter orientation="-" count="2" sizes="0.500772;0.499228">
+     <DockSplitter orientation="|" count="3" sizes="0.333045;0.33391;0.333045">
+      <DockArea name="Velocity Controller Info">
+       <plot mode="TimeSeries" style="Lines">
+        <range bottom="-0.009500" right="26.268925" top="0.389492" left="0.000000"/>
+        <limitY/>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.3" color="#1ac938">
+         <transform name="Scale/Offset" alias="FF">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.14" color="#ff7f0e">
+         <transform name="Scale/Offset" alias="FF+FB">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.19" color="#f14cc1">
+         <transform name="Scale/Offset" alias="FB-P">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.20" color="#9467bd">
+         <transform name="Scale/Offset" alias="FB-I">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.21" color="#17becf">
+         <transform name="Scale/Offset" alias="FB-D">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.15" color="#bcbd22">
+         <transform name="Scale/Offset" alias="acc filtered">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.16" color="#1f77b4">
+         <transform name="Scale/Offset" alias="jerk filtered">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.17" color="#d62728">
+         <transform name="Scale/Offset" alias="slope added">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.18" color="#1ac938">
+         <transform name="Scale/Offset" alias="final">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.25" color="#ff7f0e">
+         <transform name="Scale/Offset" alias="calculated">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+       </plot>
+      </DockArea>
+      <DockArea name="State">
+       <plot mode="TimeSeries" style="Lines">
+        <range bottom="0.900000" right="26.268925" top="1.100000" left="0.000000"/>
+        <limitY/>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.13" color="#d62728">
+         <transform name="Scale/Offset" alias="state 0:Init 1:Ctrl 2:Stopped 3:SmoothStop 4:Emergency 5:Error">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+       </plot>
+      </DockArea>
+      <DockArea name="Stop Dist">
+       <plot mode="TimeSeries" style="Lines">
+        <range bottom="-2.402500" right="26.261692" top="-2.297500" left="0.414630"/>
+        <limitY/>
+        <curve name="/planning/scenario_planning/motion_velocity_optimizer/distance_to_stopline/data" color="#1f77b4">
+         <transform name="Scale/Offset" alias="stop dist">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+       </plot>
+      </DockArea>
+     </DockSplitter>
+     <DockSplitter orientation="|" count="3" sizes="0.332181;0.335638;0.332181">
+      <DockArea name="Pacmod">
+       <plot mode="TimeSeries" style="Lines">
+        <range bottom="0.000000" right="1.000000" top="1.000000" left="0.000000"/>
+        <limitY/>
+       </plot>
+      </DockArea>
+      <DockArea name="Velocity">
+       <plot mode="TimeSeries" style="Lines">
+        <range bottom="-0.025000" right="26.280226" top="1.025000" left="0.000000"/>
+        <limitY/>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.2" color="#17becf">
+         <transform name="Scale/Offset" alias="target">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.1" color="#9467bd">
+         <transform name="Scale/Offset" alias="current">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.4" color="#bcbd22">
+         <transform name="Scale/Offset" alias="closest">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/control/trajectory_follower/velocity_controller/debug_values/data.24" color="#1f77b4">
+         <transform name="Scale/Offset" alias="predicted">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+        <curve name="/vehicle/status/control_mode/data" color="#d62728">
+         <transform name="Scale/Offset" alias="Control Mode">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+        </curve>
+       </plot>
+      </DockArea>
+      <DockArea name="...">
+       <plot mode="TimeSeries" style="Lines">
+        <range bottom="0.000000" right="1.000000" top="1.000000" left="0.000000"/>
+        <limitY/>
+       </plot>
+      </DockArea>
+     </DockSplitter>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <currentTabIndex index="0"/>
+ </tabbed_widget>
+ <use_relative_time_offset enabled="1"/>
+ <!-- - - - - - - - - - - - - - - -->
+ <!-- - - - - - - - - - - - - - - -->
+ <Plugins>
+  <plugin ID="DataLoad CSV">
+   <default time_axis=""/>
+  </plugin>
+  <plugin ID="DataLoad ROS2 bags">
+   <use_header_stamp value="false"/>
+   <discard_large_arrays value="true"/>
+   <max_array_size value="99"/>
+  </plugin>
+  <plugin ID="DataLoad ULog"/>
+  <plugin ID="MQTT Subscriber"/>
+  <plugin ID="ROS2 Topic Subscriber">
+   <use_header_stamp value="false"/>
+   <discard_large_arrays value="false"/>
+   <max_array_size value="true"/>
+   <selected_topics>
+    <topic name="/control/trajectory_follower/velocity_controller/debug_values"/>
+    <topic name="/planning/scenario_planning/motion_velocity_optimizer/distance_to_stopline"/>
+    <topic name="/vehicle/status/control_mode"/>
+   </selected_topics>
+  </plugin>
+  <plugin ID="UDP Server"/>
+  <plugin ID="WebSocket Server"/>
+  <plugin ID="ZMQ Subscriber"/>
+  <plugin ID="ROS2 Topic Re-Publisher" status="idle"/>
+ </Plugins>
+ <!-- - - - - - - - - - - - - - - -->
+ <previouslyLoaded_Datafiles/>
+ <previouslyLoaded_Streamer name="ROS2 Topic Subscriber"/>
+ <!-- - - - - - - - - - - - - - - -->
+ <customMathEquations/>
+ <snippets/>
+ <!-- - - - - - - - - - - - - - - -->
+</root>
+


### PR DESCRIPTION
Add config files of plot-juggler (mpc_follower, velocity_controller)

## How to check

### Install the plot-juggler
- sudo apt install ros-foxy-plotjuggler-ros
- sudo apt install ros-foxy-plotjuggler

### Launch Autoware and plotjuggler
- ros2 launch autoware_launch planning_simulator.launch.xml vehicle_model:=lexus vehicle_id:=default sensor_model:=aip_xx1 map_path:=MAP_PATH
- ros2 run plotjuggler plotjuggler

###  Load config file
- Push this button at the top left of the window and load the config files (plot_juggler_mpc_follower.xml or plot_juggler_velocity_controller.xml)
![image](https://user-images.githubusercontent.com/59680180/111945258-b9f33100-8b1c-11eb-9d23-aa714c829b92.png)
- When loading config files, Set "maximum size of arrays" to 100
![image](https://user-images.githubusercontent.com/59680180/111946240-73063b00-8b1e-11eb-97f1-803c45cb3893.png)
- Confirm each graph is plotted normally.

![image](https://user-images.githubusercontent.com/59680180/111946436-d85a2c00-8b1e-11eb-9cfc-77cffd4ebb9b.png)
