### PR TITLE
add use_sim-time option

### DIFF
--- a/awapi/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
+++ b/awapi/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
@@ -89,6 +89,7 @@
   <group>
     <push-ros-namespace namespace="awapi"/>
     <node pkg="awapi_awiv_adapter" exec="awapi_awiv_adapter" output="screen">
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <remap from="input/steer" to="$(var input_steer)" />
       <remap from="input/vehicle_cmd" to="$(var input_vehicle_cmd)" />
       <remap from="input/turn_signal" to="$(var input_turn_signal)" />
@@ -133,16 +134,19 @@
 
     <!-- relay get topic -->
     <node pkg="topic_tools" exec="relay" name="route_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var input_route)" />
       <param name="output_topic" value="$(var get_route)" />
       <param name="type" value="autoware_planning_msgs/msg/Route" />
     </node>
     <node pkg="topic_tools" exec="relay" name="predict_object_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var input_object)" />
       <param name="output_topic" value="$(var get_predicted_object)" />
       <param name="type" value="autoware_perception_msgs/msg/DynamicObjectArray" />
     </node>
     <node pkg="topic_tools" exec="relay" name="nearest_traffic_light_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var input_nearest_traffic_light_state)" />
       <param name="output_topic" value="$(var get_nearest_traffic_light_status)" />
       <param name="type" value="autoware_perception_msgs/msg/TrafficLightStateStamped" />
@@ -150,83 +154,99 @@
 
     <!-- relay put topic -->
     <node pkg="topic_tools" exec="relay" name="gate_mode_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_gate_mode)" />
       <param name="output_topic" value="$(var output_gate_mode)" />
       <param name="type" value="autoware_control_msgs/msg/GateMode" />
     </node>
     <node pkg="topic_tools" exec="relay" name="emergency_stop_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_emergency_stop)" />
       <param name="output_topic" value="$(var output_emergency_stop)" />
       <param name="type" value="autoware_control_msgs/msg/EmergencyMode" />
     </node>
     <node pkg="topic_tools" exec="relay" name="autoware_engage_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_engage)" />
       <param name="output_topic" value="$(var output_autoware_engage)" />
       <param name="type" value="autoware_vehicle_msgs/msg/Engage" />
     </node>
     <node pkg="topic_tools" exec="relay" name="vehicle_engage_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_engage)" />
       <param name="output_topic" value="$(var output_vehicle_engage)" />
       <param name="type" value="autoware_vehicle_msgs/msg/Engage" />
     </node>
     <node pkg="topic_tools" exec="relay" name="put_route_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_route)" />
       <param name="output_topic" value="$(var output_route)" />
       <param name="type" value="autoware_planning_msgs/msg/Route" />
       <param name="durability" value="transient_local" />
     </node>
     <node pkg="topic_tools" exec="relay" name="put_goal_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_goal)" />
       <param name="output_topic" value="$(var output_goal)" />
       <param name="type" value="geometry_msgs/msg/PoseStamped" />
     </node>
     <node pkg="topic_tools" exec="relay" name="lane_change_approval_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_lane_change_approval)" />
       <param name="output_topic" value="$(var output_lane_change_approval)" />
       <param name="type" value="autoware_planning_msgs/msg/LaneChangeCommand" />
     </node>
     <node pkg="topic_tools" exec="relay" name="force_lane_change_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_force_lane_change)" />
       <param name="output_topic" value="$(var output_force_lane_change)" />
       <param name="type" value="autoware_planning_msgs/msg/LaneChangeCommand" />
     </node>
     <node pkg="topic_tools" exec="relay" name="obstacle_avoid_approval_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_obstacle_avoid_approval)" />
       <param name="output_topic" value="$(var output_obstacle_avoid_approval)" />
       <param name="type" value="autoware_planning_msgs/msg/EnableAvoidance" />
     </node>
     <!-- not implemented
     <node pkg="topic_tools" exec="relay" name="force_obstacle_avoid_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_force_obstacle_avoid)" />
       <param name="output_topic" value="$(var output_force_obstacle_avoid)" />
       <param name="type" value="" />
     </node> -->
     <node pkg="topic_tools" exec="relay" name="traffic_light_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var input_traffic_light_state)" />
       <param name="output_topic" value="$(var get_traffic_light_status)" />
       <param name="type" value="autoware_perception_msgs/msg/TrafficLightStateArray" />
     </node>
     <node pkg="topic_tools" exec="relay" name="speed_exceeded_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var input_stop_speed_exceeded)" />
       <param name="output_topic" value="$(var get_stop_speed_exceeded)" />
       <param name="type" value="autoware_planning_msgs/msg/StopSpeedExceeded" />
     </node>
     <node pkg="topic_tools" exec="relay" name="crosswalk_status_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_crosswalk_status)" />
       <param name="output_topic" value="$(var input_external_crosswalk_status)" />
       <param name="type" value="autoware_api_msgs/msg/CrosswalkStatus" />
     </node>
     <node pkg="topic_tools" exec="relay" name="intersection_status_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_intersection_status)" />
       <param name="output_topic" value="$(var input_external_intersection_status)" />
       <param name="type" value="autoware_api_msgs/msg/IntersectionStatus" />
     </node>
     <node pkg="topic_tools" exec="relay" name="expand_stop_range_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_expand_stop_range)" />
       <param name="output_topic" value="$(var input_expand_stop_range)" />
       <param name="type" value="autoware_planning_msgs/msg/ExpandStopRange" />
     </node>
     <node pkg="topic_tools" exec="relay" name="pose_initialization_request_relay" output="log" >
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_topic" value="$(var set_pose_initialization_request)" />
       <param name="output_topic" value="$(var input_pose_initialization_request)" />
       <param name="type" value="autoware_localization_msgs/msg/PoseInitializationRequest" />

--- a/common/util/goal_distance_calculator/launch/goal_distance_calculator.launch.xml
+++ b/common/util/goal_distance_calculator/launch/goal_distance_calculator.launch.xml
@@ -2,6 +2,7 @@
   <arg name="oneshot" default="false" />
   <arg name="config_file" default="$(find-pkg-share goal_distance_calculator)/config/goal_distance_calculator.param.yaml" />
   <node pkg="goal_distance_calculator" exec="goal_distance_calculator_node" name="goal_distance_calculator" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var config_file)"/>
     <param name="oneshot" value="$(var oneshot)"/>
   </node>

--- a/common/util/web_controller/autoware_web_controller/launch/autoware_web_controller.launch.xml
+++ b/common/util/web_controller/autoware_web_controller/launch/autoware_web_controller.launch.xml
@@ -3,5 +3,7 @@
   <!-- Web Controller -->
 
   <executable cmd="python3 -m http.server 8085" cwd="$(find-pkg-share autoware_web_controller)/www" name="web_server"/>
-  <node pkg="rosbridge_server" exec="rosbridge_websocket" name="rosbridge_server_node" />
+  <node pkg="rosbridge_server" exec="rosbridge_websocket" name="rosbridge_server_node" >
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
+  </node>
 </launch>

--- a/control/autoware_joy_controller/launch/autoware_joy_controller.launch.xml
+++ b/control/autoware_joy_controller/launch/autoware_joy_controller.launch.xml
@@ -16,6 +16,7 @@
   <arg name="config_file" default="$(find-pkg-share autoware_joy_controller)/config/autoware_joy_controller.param.yaml" />
 
   <node pkg="autoware_joy_controller" exec="autoware_joy_controller" name="autoware_joy_controller" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/joy" to="$(var input_joy)"/>
     <remap from="input/twist" to="$(var input_twist)"/>
 
@@ -40,6 +41,7 @@
   </node>
 
   <node pkg="joy" exec="joy_node" name="joy_node" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param name="autorepeat_rate" value="1.0" />
     <param name="deadzone" value="0.0" />
   </node>

--- a/control/mpc_follower/launch/mpc_follower.launch.xml
+++ b/control/mpc_follower/launch/mpc_follower.launch.xml
@@ -5,6 +5,7 @@
 
   <!-- mpc for trajectory following -->
   <node pkg="mpc_follower" exec="mpc_follower" name="mpc_follower" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var mpc_follower_param_path)"/>
     <param from="$(var vehicle_param_file)" />
     <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>

--- a/control/pure_pursuit/launch/pure_pursuit.launch.xml
+++ b/control/pure_pursuit/launch/pure_pursuit.launch.xml
@@ -8,6 +8,7 @@
   <arg name="output/control_raw" default="lateral/control_cmd"/>
 
   <node pkg="pure_pursuit" exec="pure_pursuit" name="pure_pursuit" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var vehicle_param_file)" />
     <remap from="input/reference_trajectory" to="$(var input/reference_trajectory)"/>
     <remap from="input/current_velocity" to="$(var input/current_velocity)"/>

--- a/control/shift_decider/launch/shift_decider.launch.xml
+++ b/control/shift_decider/launch/shift_decider.launch.xml
@@ -1,5 +1,6 @@
 <launch>
   <node pkg="shift_decider" exec="shift_decider" name="shift_decider" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd" />
     <remap from="output/shift_cmd" to="/control/shift_decider/shift_cmd" />
   </node>

--- a/control/trajectory_follower/lane_departure_checker/launch/lane_departure_checker.launch.xml
+++ b/control/trajectory_follower/lane_departure_checker/launch/lane_departure_checker.launch.xml
@@ -8,6 +8,7 @@
   <arg name="config_file" default="$(find-pkg-share lane_departure_checker)/config/lane_departure_checker.param.yaml" />
 
   <node pkg="lane_departure_checker" exec="lane_departure_checker_node" name="lane_departure_checker_node" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="~/input/twist" to="$(var input/twist)"/>
     <remap from="~/input/lanelet_map_bin" to="$(var input/lanelet_map_bin)"/>
     <remap from="~/input/route" to="$(var input/route)"/>

--- a/control/vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
+++ b/control/vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
@@ -5,6 +5,7 @@
   <arg name="use_external_emergency_stop" default="true" />
 
   <node pkg="vehicle_cmd_gate" exec="vehicle_cmd_gate" name="vehicle_cmd_gate" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var vehicle_param_file)" />
     <remap from="input/engage" to="/autoware/engage"/>
     <remap from="input/system_emergency" to="/system/emergency/is_emergency"/>

--- a/control/velocity_controller/launch/velocity_controller.launch.xml
+++ b/control/velocity_controller/launch/velocity_controller.launch.xml
@@ -13,6 +13,7 @@
   <arg name="vehicle_param_file"/>
 
   <node pkg="velocity_controller" exec="velocity_controller" name="velocity_controller" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var velocity_controller_param_path)"/>
     <param from="$(var vehicle_param_file)"/>
 

--- a/localization/localization_diagnostics/localization_error_monitor/launch/localization_error_monitor.launch.xml
+++ b/localization/localization_diagnostics/localization_error_monitor/launch/localization_error_monitor.launch.xml
@@ -2,6 +2,7 @@
   <arg name="input/pose_with_cov" default="/localization/pose_twist_fusion_filter/pose_with_covariance" />
 
   <node name="localization_error_monitor" exec="localization_error_monitor" pkg="localization_error_monitor" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/pose_with_cov" to="$(var input/pose_with_cov)" />
     <param name="scale" value="3.0" />
     <param name="error_ellipse_size" value="1.0" />

--- a/map/map_loader/launch/lanelet2_map_loader.launch.xml
+++ b/map/map_loader/launch/lanelet2_map_loader.launch.xml
@@ -5,6 +5,7 @@
   <arg name="center_line_resolution" default="5.0"/>
 
   <node pkg="map_loader" exec="lanelet2_map_loader" name="lanelet2_map_loader" args="$(var file_name)">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="output/lanelet2_map" to="$(var lanelet2_map_topic)" />
     <param name="center_line_resolution" value="$(var center_line_resolution)" />
   </node>

--- a/perception/object_recognition/detection/bev_optical_flow/launch/bev_optical_flow.launch.xml
+++ b/perception/object_recognition/detection/bev_optical_flow/launch/bev_optical_flow.launch.xml
@@ -18,6 +18,7 @@
   <node name="optical_flow_node"
         pkg="bev_optical_flow" type="optical_flow_node"
         output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="~input_cloud" to="$(arg input_cloud)" />
     <rosparam subst_value="true">
       debug: $(arg debug)

--- a/perception/object_recognition/detection/euclidean_cluster/launch/euclidean_cluster.launch.xml
+++ b/perception/object_recognition/detection/euclidean_cluster/launch/euclidean_cluster.launch.xml
@@ -7,6 +7,7 @@
   <arg name="use_pointcloud_map" default="false"/>
 
   <include file="$(find-pkg-share euclidean_cluster)/launch/euclidean_cluster.launch.py">
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="input_points_raw_list" value="$(var input_pointcloud)" />
       <param name="input_map" value="$(var input_map)" />
       <param name="output_clusters" value="$(var output_clusters)" />

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/launch/lidar_apollo_instance_segmentation.launch.xml
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/launch/lidar_apollo_instance_segmentation.launch.xml
@@ -16,6 +16,7 @@
 
   <node pkg="lidar_apollo_instance_segmentation" exec="lidar_apollo_instance_segmentation_node"
         name="lidar_apollo_instance_segmentation" output="screen" >
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/pointcloud" to="/sensing/lidar/top/rectified/pointcloud"/>
     <remap from="output/labeled_clusters" to="$(var output/objects)"/>
     <param name="engine_file" value="$(var trained_engine_file)"/>

--- a/perception/object_recognition/detection/object_flow_fusion/launch/object_flow_fusion.launch.xml
+++ b/perception/object_recognition/detection/object_flow_fusion/launch/object_flow_fusion.launch.xml
@@ -7,6 +7,7 @@
   <node name="object_flow_fusion_node"
         pkg="object_flow_fusion" type="object_flow_fusion_node"
         output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="~input_object" to="$(arg input_object)" />
     <remap from="~input_flow" to="$(arg input_flows)" />
     <rosparam subst_value="true">

--- a/perception/object_recognition/detection/object_merger/launch/object_association_merger.launch.xml
+++ b/perception/object_recognition/detection/object_merger/launch/object_association_merger.launch.xml
@@ -6,6 +6,7 @@
   <arg name="output/object" default="merged_object"/>
 
   <node pkg="object_merger" exec="object_association_merger_node" name="object_association_merger" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/object0" to="$(var input/object0)"/>
     <remap from="input/object1" to="$(var input/object1)"/>
     <remap from="output/object" to="$(var output/object)"/>

--- a/perception/object_recognition/detection/object_range_splitter/launch/object_range_splitter.launch.xml
+++ b/perception/object_recognition/detection/object_range_splitter/launch/object_range_splitter.launch.xml
@@ -7,6 +7,7 @@
   <arg name="split_range" default="30.0"/>
 
   <node pkg="object_range_splitter" exec="object_range_splitter_node" name="object_range_splitter" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/object" to="$(var input/object)"/>
     <remap from="output/long_range_object" to="$(var output/long_range_object)"/>
     <remap from="output/short_range_object" to="$(var output/short_range_object)"/>

--- a/perception/object_recognition/detection/roi_cluster_fusion/launch/roi_cluster_fusion.launch.xml
+++ b/perception/object_recognition/detection/roi_cluster_fusion/launch/roi_cluster_fusion.launch.xml
@@ -34,6 +34,7 @@
   <arg name="input/image7" default="/image_raw7"/>
 
   <node pkg="roi_cluster_fusion" exec="roi_cluster_fusion_node" name="roi_cluster_fusion">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param name="use_iou" value="true"/>
     <param name="use_iou_x" value="false"/>
     <param name="use_iou_y" value="false"/>

--- a/perception/object_recognition/detection/shape_estimation/launch/shape_estimation.launch.xml
+++ b/perception/object_recognition/detection/shape_estimation/launch/shape_estimation.launch.xml
@@ -11,6 +11,7 @@
   <arg name="orientation_reliable" default="true"/>
   <!-- 70 deg -->
   <node pkg="shape_estimation" exec="shape_estimation" name="$(var node_name)" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input" to="$(var input/objects)" />
     <remap from="objects" to="$(var output/objects)" />
     <param name="use_corrector" value="$(var use_corrector)" />

--- a/perception/object_recognition/detection/tensorrt_yolo/launch/tensorrt_yolo.launch.xml
+++ b/perception/object_recognition/detection/tensorrt_yolo/launch/tensorrt_yolo.launch.xml
@@ -6,6 +6,7 @@
   <arg name="calib_image_directory" default="$(find-pkg-share tensorrt_yolo)/calib_image/"/>
   <arg name="mode" default="FP32"/>
   <node pkg="tensorrt_yolo" exec="tensorrt_yolo_node" name="$(anon tensorrt_yolo)" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="in/image" to="$(var input_topic)" />
     <remap from="out/objects" to="$(var output_topic)" />
     <remap from="out/image" to="$(var output_topic)/debug/image" />

--- a/perception/object_recognition/prediction/map_based_prediction/launch/map_based_prediction.launch.xml
+++ b/perception/object_recognition/prediction/map_based_prediction/launch/map_based_prediction.launch.xml
@@ -6,6 +6,7 @@
   <arg name="vector_map_topic" default="/map/vector_map" />
   <arg name="output_topic" default="objects"/>
   <node pkg="map_based_prediction" exec="map_based_prediction" name="map_based_prediction" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param name="perception_time_horizon" value="$(var prediction_time_horizon)" />
     <param name="prediction_sampling_delta_time" value="$(var prediction_sampling_delta_time)" />
     <remap from="/vector_map" to="$(var vector_map_topic)"/>

--- a/perception/object_recognition/prediction/naive_path_prediction/launch/naive_path_prediction.launch.xml
+++ b/perception/object_recognition/prediction/naive_path_prediction/launch/naive_path_prediction.launch.xml
@@ -3,6 +3,7 @@
   <arg name="output/objects" default="objects"/>
 
   <node pkg="naive_path_prediction" exec="naive_path_prediction_node" name="naive_path_prediction" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input" to="$(var input/objects)"/>
     <remap from="output" to="$(var output/objects)"/>
   </node>

--- a/perception/object_recognition/tracking/multi_object_tracker/launch/multi_object_tracker.launch.xml
+++ b/perception/object_recognition/tracking/multi_object_tracker/launch/multi_object_tracker.launch.xml
@@ -8,6 +8,7 @@
   <arg name="data_association_matrix_path" default="$(find-pkg-share multi_object_tracker)/config/data_association_matrix.param.yaml" />
 
   <node pkg="multi_object_tracker" exec="multi_object_tracker" name="multi_object_tracker" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input" to="$(var input)"/>
     <remap from="output" to="$(var output)"/>
     <param name="world_frame_id" value="$(var world_frame_id)" />

--- a/perception/traffic_light_recognition/traffic_light_classifier/launch/traffic_light_classifier.launch.xml
+++ b/perception/traffic_light_recognition/traffic_light_classifier/launch/traffic_light_classifier.launch.xml
@@ -10,6 +10,7 @@
   <arg name="classifier_type" default="0" unless="$(var use_gpu)"/>
 
   <node pkg="traffic_light_classifier" exec="traffic_light_classifier_node" name="traffic_light_classifier">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/image" to="$(var input/image)" />
     <remap from="input/rois" to="$(var input/rois)" />
     <remap from="output/traffic_light_states" to="$(var output/traffic_light_states)" />

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/launch/traffic_light_map_based_detector.launch.xml
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/launch/traffic_light_map_based_detector.launch.xml
@@ -9,6 +9,7 @@
   <arg name="param_path" default="$(find-pkg-share traffic_light_map_based_detector)/config/traffic_light_map_based_detector.param.yaml" />
 
   <node pkg="traffic_light_map_based_detector" exec="traffic_light_map_based_detector_node" name="traffic_light_map_based_detector" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/vector_map" to="$(var input/vector_map)" />
     <remap from="input/camera_info" to="$(var input/camera_info)" />
     <remap from="input/route" to="$(var input/route)" />

--- a/perception/traffic_light_recognition/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
+++ b/perception/traffic_light_recognition/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
@@ -15,6 +15,7 @@
   <arg name="manager" default="traffic_light_recognition_nodelet_manager"/>
 
   <node pkg="traffic_light_ssd_fine_detector" exec="traffic_light_ssd_fine_detector_node" name="traffic_light_ssd_fine_detector">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/image" to="$(var input/image)" />
     <remap from="input/rois" to="$(var input/rois)" />
     <remap from="output/rois" to="$(var output/rois)" />
@@ -29,6 +30,7 @@
   </node>
 
   <node if="$(var save_rough_roi_image)" pkg="roi_image_saver" exec="traffic_light_roi_image_saver_node" name="$(anon traffic_light_roi_image_saver)" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/image" to="$(var input/image)"/>
     <remap from="input/rois" to="$(var input/rois)"/>
     <param name="save_dir" value="$(find-pkg-share roi_image_saver)/train_image"/>

--- a/perception/util/visualizer/dynamic_object_visualization/launch/dynamic_object_visualizer.launch.xml
+++ b/perception/util/visualizer/dynamic_object_visualization/launch/dynamic_object_visualizer.launch.xml
@@ -7,6 +7,7 @@
   <arg name="only_known_objects" default="true"/>
 
   <node pkg="dynamic_object_visualization" exec="dynamic_object_visualizer_node" name="$(anon dynamic_object_visualization)" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input" to="$(var input)"/>
     <remap from="output" to="$(var input)/visualization"/>
     <param name="with_feature" value="$(var with_feature)"/>

--- a/perception/util/visualizer/traffic_light_visualization/launch/traffic_light_roi_visualizer.launch.xml
+++ b/perception/util/visualizer/traffic_light_visualization/launch/traffic_light_roi_visualizer.launch.xml
@@ -10,6 +10,7 @@
   <arg name="manager" default="traffic_light_recognition_nodelet_manager"/>
 
   <node pkg="traffic_light_visualization" exec="traffic_light_visualization_node" name="traffic_light_visualization">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/image" to="$(var input/image)"/>
     <remap from="input/rois" to="$(var input/rois)"/>
     <remap from="input/rough/rois" to="$(var input/rough/rois)"/>

--- a/planning/mission_planning/mission_planner/launch/goal_pose_visualizer.launch.xml
+++ b/planning/mission_planning/mission_planner/launch/goal_pose_visualizer.launch.xml
@@ -3,6 +3,7 @@
   <arg name="echo_back_goal_pose_topic_name" default="/planning/mission_planning/echo_back_goal_pose" />
 
   <node pkg="mission_planner" exec="goal_pose_visualizer" name="goal_pose_visualizer" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/route" to="$(var rout_topic_name)" />
     <remap from="output/goal_pose" to="$(var echo_back_goal_pose_topic_name)" />
   </node>

--- a/planning/mission_planning/mission_planner/launch/mission_planner.launch.xml
+++ b/planning/mission_planning/mission_planner/launch/mission_planner.launch.xml
@@ -6,6 +6,7 @@
   <arg name="visualization_topic_name" default="/planning/mission_planning/route_marker" />
 
   <node pkg="mission_planner" exec="mission_planner" name="mission_planner" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param name="map_frame" value="map" />
     <param name="base_link_frame" value="base_link" />
     <remap from="input/vector_map" to="$(var map_topic_name)" />

--- a/planning/scenario_planning/common/motion_velocity_optimizer/launch/motion_velocity_optimizer.launch.xml
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/launch/motion_velocity_optimizer.launch.xml
@@ -12,6 +12,7 @@
   <arg name="param_path" default="$(find-pkg-share motion_velocity_optimizer)/config/motion_velocity_optimizer.param.yaml" />
 
   <node pkg="motion_velocity_optimizer" exec="motion_velocity_optimizer" name="motion_velocity_optimizer" output="log">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var param_path)" />
     <param name="show_debug_info" value="$(var show_debug_info)"/>
     <param name="show_debug_info_all" value="$(var show_debug_info_all)"/>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
@@ -19,6 +19,7 @@
   <arg name="vehicle_param_file" />
 
   <node pkg="behavior_velocity_planner" exec="behavior_velocity_planner_node" name="behavior_velocity_planner" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(find-pkg-share behavior_velocity_planner)/config/blind_spot.param.yaml" />
     <param from="$(find-pkg-share behavior_velocity_planner)/config/crosswalk.param.yaml" />
     <param from="$(find-pkg-share behavior_velocity_planner)/config/detection_area.param.yaml" />

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/launch/obstacle_avoidance_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/launch/obstacle_avoidance_planner.launch.xml
@@ -9,6 +9,7 @@
 
   <node pkg="obstacle_avoidance_planner" exec="obstacle_avoidance_planner_node"
     name="obstacle_avoidance_planner" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="~/input/objects" to="$(var input_objects)"/>
     <remap from="~/input/path" to="$(var input_path_topic)" />
     <remap from="~/output/path" to="$(var output_path_topic)" />

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
@@ -10,6 +10,7 @@
   <arg name="vehicle_param_file"/>
 
   <node pkg="obstacle_stop_planner" exec="obstacle_stop_planner_node" name="obstacle_stop_planner" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var vehicle_param_file)" />
     <param from="$(var acc_param_file)" />
     <param from="$(var param_file)" />

--- a/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
@@ -9,6 +9,7 @@
   <arg name="output_trajectory" default="output/trajectory" />
 
   <node pkg="surround_obstacle_checker" exec="surround_obstacle_checker_node" name="surround_obstacle_checker" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var param_path)" />
     <param from="$(var vehicle_param_file)" />
     <remap from="~/output/no_start_reason" to="/planning/scenario_planning/status/no_start_reason" />

--- a/planning/scenario_planning/parking/costmap_generator/launch/costmap_generator.launch.xml
+++ b/planning/scenario_planning/parking/costmap_generator/launch/costmap_generator.launch.xml
@@ -7,6 +7,7 @@
   <arg name="output_occupancy_grid" default="~/output/occupancy_grid"/>
 
   <node pkg="costmap_generator" exec="costmap_generator" name="costmap_generator" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="~/input/objects" to="$(var input_objects)" />
     <remap from="~/input/points_no_ground" to="$(var input_points_no_ground)" />
     <remap from="~/input/vector_map" to="$(var input_lanelet_map)" />

--- a/planning/scenario_planning/parking/freespace_planner/launch/freespace_planner.launch.xml
+++ b/planning/scenario_planning/parking/freespace_planner/launch/freespace_planner.launch.xml
@@ -7,6 +7,7 @@
   <arg name="is_completed" default="is_completed"/>
 
   <node pkg="freespace_planner" exec="freespace_planner" name="freespace_planner" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="~/input/route" to="$(var input_route)" />
     <remap from="~/input/occupancy_grid" to="$(var input_occupancy_grid)" />
     <remap from="~/input/scenario" to="$(var input_scenario)" />

--- a/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_lane_driving.launch.xml
+++ b/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_lane_driving.launch.xml
@@ -10,6 +10,7 @@
   <arg name="is_parking_completed" default="" />
 
   <node pkg="topic_tools" exec="relay" name="scenario_trajectory_relay" output="log" >
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param name="input_topic" value="$(var input_lane_driving_trajectory)" />
     <param name="output_topic" value="$(var output_trajectory)" />
     <param name="type" value="autoware_planning_msgs/msg/Trajectory" />

--- a/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_parking.launch.xml
+++ b/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_parking.launch.xml
@@ -10,6 +10,7 @@
   <arg name="is_parking_completed" default="" />
 
   <node pkg="topic_tools" exec="relay" name="scenario_trajectory_relay" output="log" >
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param name="input_topic" value="$(var input_parking_trajectory)" />
     <param name="output_topic" value="$(var output_trajectory)" />
     <param name="type" value="autoware_planning_msgs/msg/Trajectory" />

--- a/planning/scenario_planning/scenario_selector/launch/scenario_selector.launch.xml
+++ b/planning/scenario_planning/scenario_selector/launch/scenario_selector.launch.xml
@@ -10,6 +10,7 @@
   <arg name="output_trajectory" />
 
   <node pkg="scenario_selector" exec="scenario_selector" name="scenario_selector" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/lane_driving/trajectory" to="$(var input_lane_driving_trajectory)"/>
     <remap from="input/parking/trajectory" to="$(var input_parking_trajectory)"/>
     <remap from="input/lanelet_map" to="$(var input_lanelet_map)"/>

--- a/sensing/preprocessor/gnss/gnss_poser/launch/ubloxfix2mgrs.launch.xml
+++ b/sensing/preprocessor/gnss/gnss_poser/launch/ubloxfix2mgrs.launch.xml
@@ -4,6 +4,7 @@
   <arg name="input_topic_navpvt" default="/ublox/navpvt" />
 
   <include file="$(find-pkg-share gnss_poser)/launch/gnss_poser.launch.xml" >
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <arg name="input_topic_fix" value="$(var input_topic_fix)" />
     <arg name="input_topic_navpvt" value="$(var input_topic_navpvt)" />
     <arg name="coordinate_system" value="1" doc="0:UTM, 1:MGRS, 2:PLANE" />

--- a/sensing/preprocessor/pointcloud/livox/livox_tag_filter/launch/livox_tag_filter.launch.xml
+++ b/sensing/preprocessor/pointcloud/livox/livox_tag_filter/launch/livox_tag_filter.launch.xml
@@ -5,6 +5,7 @@
   <arg name="ignore_tags" doc="tags to be ignored" />
 
   <node pkg="livox_tag_filter" exec="livox_tag_filter_node" name="livox_tag_filter_node" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input" to="$(var input)"/>
     <remap from="output" to="$(var output)"/>
     <param name="ignore_tags" value="$(var ignore_tags)"/>

--- a/sensing/preprocessor/pointcloud/pointcloud_preprocessor/launch/random_downsample_filter.launch.xml
+++ b/sensing/preprocessor/pointcloud/pointcloud_preprocessor/launch/random_downsample_filter.launch.xml
@@ -7,6 +7,7 @@
   <arg name="output_frame" default="base_link" />
 
   <node pkg="pointcloud_preprocessor" exec="random_downsample_filter_node" name="random_downsample_filter">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input" to="$(var input_topic_name)" />
     <remap from="output" to="$(var output_topic_name)" />
 

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.xml
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.xml
@@ -13,6 +13,7 @@
 
   <!-- simple_planning_simulator node -->
   <node pkg="simple_planning_simulator" exec="simple_planning_simulator_exe" name="simple_planning_simulator" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="/base_trajectory" to="/planning/scenario_planning/trajectory" />
     <remap from="output/current_pose" to="current_pose" />
     <remap from="output/current_twist" to="/vehicle/status/twist" />
@@ -36,6 +37,7 @@
   </node>
 
   <node pkg="topic_tools" exec="relay" name="twist_relay" output="log" >
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param name="input_topic" value="/vehicle/status/twist" />
     <param name="output_topic" value="/localization/twist" />
     <param name="type" value="geometry_msgs/msg/TwistStamped" />

--- a/simulator/util/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
+++ b/simulator/util/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
@@ -9,6 +9,7 @@
     <push-ros-namespace namespace="simulation"/>
     <group if="$(var real)">
       <node pkg="dummy_perception_publisher" exec="dummy_perception_publisher_node" name="dummy_perception_publisher" output="screen">
+        <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
         <remap from="output/dynamic_object" to="/perception/object_recognition/detection/labeled_clusters" />
         <remap from="output/objects_pose" to="debug/object_pose" />
         <remap from="output/points_raw" to="/sensing/lidar/no_ground/pointcloud" />
@@ -26,6 +27,7 @@
     </group>
     <group unless="$(var real)">
       <node pkg="dummy_perception_publisher" exec="dummy_perception_publisher_node" name="dummy_perception_publisher" output="screen">
+        <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
         <remap from="output/dynamic_object" to="/perception/object_recognition/detection/objects" />
         <remap from="output/objects_pose" to="debug/object_pose" />
         <remap from="output/points_raw" to="/sensing/lidar/no_ground/pointcloud" />
@@ -64,6 +66,7 @@
     <group unless="$(var use_object_recognition)">
       <push-ros-namespace namespace="object_recognition"/>
       <node pkg="dummy_perception_publisher" exec="empty_objects_publisher" name="empty_objects_publisher" output="screen">
+        <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
         <remap from="output/objects" to="/perception/object_recognition/objects" />
       </node>
     </group>

--- a/system/autoware_error_monitor/launch/autoware_error_monitor.launch.xml
+++ b/system/autoware_error_monitor/launch/autoware_error_monitor.launch.xml
@@ -15,6 +15,7 @@
 
   <group ns="/">
     <node pkg="diagnostic_aggregator" exec="aggregator_node" name="aggregator_node" output="screen" args="--ros-args --log-level WARN">
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param name="pub_rate" value="10.0"/>
       <param name="path" value="autoware"/>
       <param from="$(var agg_config_file_discard)" />

--- a/system/autoware_error_monitor/launch/autoware_error_monitor_node.launch.xml
+++ b/system/autoware_error_monitor/launch/autoware_error_monitor_node.launch.xml
@@ -4,6 +4,7 @@
   <arg name="add_leaf_diagnostics" />
 
   <node pkg="autoware_error_monitor" exec="autoware_error_monitor" name="autoware_error_monitor" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/diag_array" to="/diagnostics_agg" />
     <remap from="output/driving_capability" to="/autoware/driving_capability" />
 

--- a/system/autoware_state_monitor/launch/autoware_state_monitor.launch.xml
+++ b/system/autoware_state_monitor/launch/autoware_state_monitor.launch.xml
@@ -26,6 +26,7 @@
   <arg name="disengage_on_goal" default="true" />
 
   <node pkg="autoware_state_monitor" exec="autoware_state_monitor" name="autoware_state_monitor" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/autoware_engage" to="$(var input_autoware_engage)"/>
     <remap from="input/vehicle_control_mode" to="$(var input_vehicle_control_mode)"/>
     <remap from="input/is_emergency" to="$(var input_is_emergency)"/>

--- a/system/emergency_handler/launch/emergency_handler.launch.xml
+++ b/system/emergency_handler/launch/emergency_handler.launch.xml
@@ -22,6 +22,8 @@
 
   <!-- emergency_handler -->
   <node pkg="emergency_handler" exec="emergency_handler" name="emergency_handler" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
+
     <remap from="~/input/autoware_state" to="$(var input_autoware_state)"/>
     <remap from="~/input/driving_capability" to="$(var input_driving_capability)"/>
     <remap from="~/input/prev_control_command" to="$(var input_prev_control_command)"/>
@@ -47,6 +49,8 @@
   <arg name="state_timeout_checker_config_file" default="$(find-pkg-share emergency_handler)/config/state_timeout_checker.param.yaml" />
 
   <node pkg="emergency_handler" exec="state_timeout_checker" name="state_timeout_checker" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
+
     <remap from="~/input/autoware_state" to="$(var input_autoware_state)"/>
 
     <remap from="~/output/is_state_timeout" to="$(var input_is_state_timeout)"/>

--- a/system/system_monitor/launch/system_monitor.launch.xml
+++ b/system/system_monitor/launch/system_monitor.launch.xml
@@ -9,24 +9,31 @@
 
   <group>
     <node pkg="system_monitor" exec="cpu_monitor" name="cpu_monitor" output="log" respawn="true">
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param from="$(var cpu_monitor_config_file)" />
     </node>
     <node pkg="system_monitor" exec="hdd_monitor" name="hdd_monitor" output="log" respawn="true">
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param from="$(var hdd_monitor_config_file)" />
     </node>
     <node pkg="system_monitor" exec="mem_monitor" name="mem_monitor" output="log" respawn="true">
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param from="$(var mem_monitor_config_file)" />
     </node>
     <node pkg="system_monitor" exec="net_monitor" name="net_monitor" output="log" respawn="true">
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param from="$(var net_monitor_config_file)" />
     </node>
     <node pkg="system_monitor" exec="ntp_monitor" name="ntp_monitor" output="log" respawn="true">
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param from="$(var ntp_monitor_config_file)" />
     </node>
     <node pkg="system_monitor" exec="process_monitor" name="process_monitor" output="log" respawn="true">
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param from="$(var process_monitor_config_file)" />
     </node>
     <node pkg="system_monitor" exec="gpu_monitor" name="gpu_monitor" output="log" respawn="true">
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param from="$(var gpu_monitor_config_file)" />
     </node>
   </group>

--- a/system/topic_state_monitor/launch/topic_state_monitor.launch.xml
+++ b/system/topic_state_monitor/launch/topic_state_monitor.launch.xml
@@ -11,6 +11,7 @@
   <arg name="window_size" default="10" doc="warn rate[Hz]" />
 
   <node pkg="topic_state_monitor" exec="topic_state_monitor_node" name="topic_state_monitor_$(var node_name_suffix)" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param name="topic" value="$(var topic)" />
     <param name="topic_type" value="$(var topic_type)" />
     <param name="transient_local" value="$(var transient_local)" />

--- a/system/util/dummy_diag_publisher/launch/dummy_diag_publisher_node.launch.xml
+++ b/system/util/dummy_diag_publisher/launch/dummy_diag_publisher_node.launch.xml
@@ -3,6 +3,7 @@
 
   <group ns="dummy_diag_publisher">
     <node pkg="dummy_diag_publisher" exec="dummy_diag_publisher" name="$(var diag_name)" output="screen">
+      <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
       <param from="$(find-pkg-share dummy_diag_publisher)/config/$(var diag_name).param.yaml" />
     </node>
   </group>

--- a/system/velodyne_monitor/launch/velodyne_monitor.launch.xml
+++ b/system/velodyne_monitor/launch/velodyne_monitor.launch.xml
@@ -3,6 +3,7 @@
   <arg name="ip_address" default="192.168.1.201" />
 
   <node pkg="velodyne_monitor" exec="velodyne_monitor" name="velodyne_monitor" output="log" respawn="true">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param from="$(var config_file)" />
     <param name="ip_address" value="$(var ip_address)" />
   </node>

--- a/tmp/trajectory_loader/launch/sample.launch.xml
+++ b/tmp/trajectory_loader/launch/sample.launch.xml
@@ -1,6 +1,7 @@
 <launch>
   <arg name="file_name" default="$(find-pkg-share trajectory_loader)/data/sample.csv" />
   <node pkg="trajectory_loader" name="trajectory_loader" exec="trajectory_loader" output="log">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <param name="trajectory_file_name" value="$(var file_name)" />
   </node>
 </launch>

--- a/vehicle/as/launch/pacmod_additional_debug_publisher.launch.xml
+++ b/vehicle/as/launch/pacmod_additional_debug_publisher.launch.xml
@@ -6,6 +6,7 @@
   <arg name="output_steer_cal_topic" default="/pacmod/parsed_tx/steer_cal_rpt"/>
   <arg name="calibration_active" default="false"/>
   <node pkg="as" exec="pacmod_additional_debug_publisher" name="pacmod_additional_debug_publisher" output="screen">
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
     <remap from="input/can_tx" to="$(var input_topic)" />
     <remap from="output/debug" to="$(var output_topic)" />
     <remap from="output/accel_cal_rpt" to="$(var output_accel_cal_topic)" />


### PR DESCRIPTION
Add use_sim_time option to all nodes

### How to check (w/ https://github.com/tier4/autoware_launcher.iv.universe/pull/99 )
- $export AW_ROS2_USE_SIM_TIME=true
- $ros2 launch autoware_launch planning_simulator.launch.xml vehicle_model:=lexus vehicle_id:=default sensor_model:=aip_xx1 map_path:=MAP_PATH
- $ros2 topic pub /autoware/engage autoware_vehicle_msgs/msg/Engage '{engage: true}' 

- Confirm that autoware work normally.
- Confirm that use_sim_time param of all nodes except for clock_publisher become True by following command.
```
node_list=$(ros2 node list);for i in ${node_list}; do  echo -e "ros2 param get $i use_sim_time\n";  ros2 param get $i use_sim_time;  echo -e "--------------------------\n"; done
```
- (Options)
You can also try running Autoware at different time scaling using following clock_publisher repositry:
https://github.com/tkimura4/clock_publisher
(Change _speed_rate_ option)


