### PR TITLE
Remove unnecessary diagnostic update.

### DIFF
--- a/system/system_monitor/include/system_monitor/utils.hpp
+++ b/system/system_monitor/include/system_monitor/utils.hpp
@@ -33,7 +33,6 @@ template<typename MonitorT>
 void spin_and_update(const std::shared_ptr<MonitorT> & monitor_ptr, std::chrono::seconds period)
 {
   while (rclcpp::ok()) {
-    monitor_ptr->update();
     rclcpp::spin_some(monitor_ptr);
     std::this_thread::sleep_for(period);
   }


### PR DESCRIPTION
- In ROS2, `diagnostic_updater::Updater` calls `update()` using timer.
https://github.com/ros/diagnostics/blob/foxy/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp#L486-L494
-  The function `spin_and_update()` calls `update() `manually.
-  `rclcpp::spin_some()` in `spin_and_update()` executes `update()` using timer.
- So, duplicated `update()` calls are made.