### PR TITLE
fix traffic light module

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -519,7 +519,8 @@ geometry_msgs::msg::Point TrafficLightModule::getTrafficLightPosition(
   const lanelet::ConstLineStringOrPolygon3d traffic_light)
 {
   geometry_msgs::msg::Point tl_center;
-  for (const auto & tl_point : *traffic_light.lineString()) {
+  const auto tl_linestring = *traffic_light.lineString();
+  for (const auto & tl_point : tl_linestring) {
     tl_center.x += tl_point.x() / (*traffic_light.lineString()).size();
     tl_center.y += tl_point.y() / (*traffic_light.lineString()).size();
     tl_center.z += tl_point.z() / (*traffic_light.lineString()).size();


### PR DESCRIPTION
Fix traffic light module

## how to check
- run the following scenario.
https://github.com/tier4/AutonomousDrivingScenarios/blob/master/odd3/scenario/UC-001-0009/PSim_1/UC-001-0009_PSim_1_case1.yaml

(Before merging this PR, the process of behavior_velocity_planner is killed soon after sending traffic_light_status)