### PR TITLE
set transit_margin_time to intersect. planner

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -42,6 +42,7 @@ IntersectionModule::IntersectionModule(
   turn_direction_ = assigned_lanelet.attributeOr("turn_direction", "else");
   has_traffic_light_ =
     !(assigned_lanelet.regulatoryElementsAs<const lanelet::TrafficLight>().empty());
+  state_machine_.setMarginTime(planner_param_.state_transit_margin_time);
 }
 
 bool IntersectionModule::modifyPathVelocity(


### PR DESCRIPTION
Fix bug:
use _state_transit_margin_time_ parameter properly in intersection planner.