### PR TITLE
Rviz overlay render fix

### DIFF
--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -102,21 +102,7 @@ void SteeringAngleDisplay::onInitialize()
 
   overlay_->show();
 
-  overlay_->updateTextureSize(property_length_->getInt(), property_length_->getInt());
-  overlay_->setPosition(property_left_->getInt(), property_top_->getInt());
-  overlay_->setDimensions(overlay_->getTextureWidth(), overlay_->getTextureHeight());
-
-  // QColor background_color;
-  // background_color.setAlpha(0);
-  // jsk_rviz_plugins::ScopedPixelBuffer buffer = overlay_->getBuffer();
-  // hud_ = buffer.getQImage(*overlay_);
-  // for (int i = 0; i < overlay_->getTextureWidth(); i++)
-  // {
-  //   for (int j = 0; j < overlay_->getTextureHeight(); j++)
-  //   {
-  //     hud_.setPixel(i, j, background_color.rgba());
-  //   }
-  // }
+  updateVisualization();
 }
 
 void SteeringAngleDisplay::onEnable()
@@ -132,19 +118,24 @@ void SteeringAngleDisplay::onDisable()
   overlay_->hide();
 }
 
-void SteeringAngleDisplay::processMessage(
-  const autoware_vehicle_msgs::msg::Steering::ConstSharedPtr msg_ptr)
+void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
 {
-  if (!isEnabled()) {
-    return;
-  }
-  if (!overlay_->isVisible()) {
-    return;
+  (void) wall_dt;
+  (void) ros_dt;
+
+  {
+    std::lock_guard<std::mutex> message_lock(mutex_);
+    if (!last_msg_ptr_) {
+      return;
+    }
   }
 
   QColor background_color;
   background_color.setAlpha(0);
   jsk_rviz_plugins::ScopedPixelBuffer buffer = overlay_->getBuffer();
+  if (!buffer.getPixelBuffer())
+    return;
+
   QImage hud = buffer.getQImage(*overlay_);
   hud.fill(background_color);
 
@@ -159,7 +150,7 @@ void SteeringAngleDisplay::processMessage(
 
   QMatrix rotation_matrix;
   rotation_matrix.rotate(
-    std::round(property_handle_angle_scale_->getFloat() * (msg_ptr->data / M_PI) * -180.0));
+    std::round(property_handle_angle_scale_->getFloat() * (last_msg_ptr_->data / M_PI) * -180.0));
   // else
   // rotation_matrix.rotate
   // ((property_handle_angle_scale_->getFloat() * (msg_ptr->data / M_PI) * -180.0));
@@ -179,15 +170,28 @@ void SteeringAngleDisplay::processMessage(
   font.setBold(true);
   painter.setFont(font);
   std::ostringstream steering_angle_ss;
-  steering_angle_ss << std::fixed << std::setprecision(1) << msg_ptr->data * 180.0 / M_PI << "deg";
+  steering_angle_ss << std::fixed << std::setprecision(1) << last_msg_ptr_->data * 180.0 / M_PI << "deg";
   painter.drawText(
     0, std::min(property_value_height_offset_->getInt(), h - 1), w,
     std::max(h - property_value_height_offset_->getInt(), 1), Qt::AlignCenter | Qt::AlignVCenter,
     steering_angle_ss.str().c_str());
 
   painter.end();
-  last_msg_ptr_ = msg_ptr;
-  updateVisualization();
+}
+
+void SteeringAngleDisplay::processMessage(
+  const autoware_vehicle_msgs::msg::Steering::ConstSharedPtr msg_ptr)
+{
+  if (!isEnabled()) {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> message_lock(mutex_);
+    last_msg_ptr_ = msg_ptr;
+  }
+
+  queueRender();
 }
 
 void SteeringAngleDisplay::updateVisualization()
@@ -195,18 +199,6 @@ void SteeringAngleDisplay::updateVisualization()
   overlay_->updateTextureSize(property_length_->getInt(), property_length_->getInt());
   overlay_->setPosition(property_left_->getInt(), property_top_->getInt());
   overlay_->setDimensions(overlay_->getTextureWidth(), overlay_->getTextureHeight());
-
-  // QColor background_color;
-  // background_color.setAlpha(0);
-  // jsk_rviz_plugins::ScopedPixelBuffer buffer = overlay_->getBuffer();
-  // hud_ = buffer.getQImage(*overlay_);
-  // for (int i = 0; i < overlay_->getTextureWidth(); i++)
-  // {
-  //   for (int j = 0; j < overlay_->getTextureHeight(); j++)
-  //   {
-  //     hud_.setPixel(i, j, background_color.rgba());
-  //   }
-  // }
 }
 
 }  // namespace rviz_plugins

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -123,11 +123,13 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   (void) wall_dt;
   (void) ros_dt;
 
+  double steering = 0;
   {
     std::lock_guard<std::mutex> message_lock(mutex_);
     if (!last_msg_ptr_) {
       return;
     }
+    steering = last_msg_ptr_->data;
   }
 
   QColor background_color;
@@ -151,7 +153,8 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
 
   QMatrix rotation_matrix;
   rotation_matrix.rotate(
-    std::round(property_handle_angle_scale_->getFloat() * (last_msg_ptr_->data / M_PI) * -180.0));
+    std::round(property_handle_angle_scale_->getFloat() * (steering / M_PI) * -180.0));
+
   // else
   // rotation_matrix.rotate
   // ((property_handle_angle_scale_->getFloat() * (msg_ptr->data / M_PI) * -180.0));
@@ -171,7 +174,7 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   font.setBold(true);
   painter.setFont(font);
   std::ostringstream steering_angle_ss;
-  steering_angle_ss << std::fixed << std::setprecision(1) << last_msg_ptr_->data * 180.0 / M_PI <<
+  steering_angle_ss << std::fixed << std::setprecision(1) << steering * 180.0 / M_PI <<
     "deg";
   painter.drawText(
     0, std::min(property_value_height_offset_->getInt(), h - 1), w,

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -94,7 +94,7 @@ SteeringAngleDisplay::~SteeringAngleDisplay()
 
 void SteeringAngleDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  MFDClass::onInitialize();
   static int count = 0;
   rviz_common::UniformStringStream ss;
   ss << "SteeringAngleDisplayObject" << count++;

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -133,8 +133,9 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   QColor background_color;
   background_color.setAlpha(0);
   jsk_rviz_plugins::ScopedPixelBuffer buffer = overlay_->getBuffer();
-  if (!buffer.getPixelBuffer())
+  if (!buffer.getPixelBuffer()) {
     return;
+  }
 
   QImage hud = buffer.getQImage(*overlay_);
   hud.fill(background_color);
@@ -170,7 +171,8 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   font.setBold(true);
   painter.setFont(font);
   std::ostringstream steering_angle_ss;
-  steering_angle_ss << std::fixed << std::setprecision(1) << last_msg_ptr_->data * 180.0 / M_PI << "deg";
+  steering_angle_ss << std::fixed << std::setprecision(1) << last_msg_ptr_->data * 180.0 / M_PI <<
+    "deg";
   painter.drawText(
     0, std::min(property_value_height_offset_->getInt(), h - 1), w,
     std::max(h - property_value_height_offset_->getInt(), 1), Qt::AlignCenter | Qt::AlignVCenter,

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -94,7 +94,7 @@ SteeringAngleDisplay::~SteeringAngleDisplay()
 
 void SteeringAngleDisplay::onInitialize()
 {
-  MFDClass::onInitialize();
+  RTDClass::onInitialize();
   static int count = 0;
   rviz_common::UniformStringStream ss;
   ss << "SteeringAngleDisplayObject" << count++;

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
@@ -18,6 +18,7 @@
 #include <deque>
 #include <iomanip>
 #include <memory>
+#include <mutex>
 
 #ifndef Q_MOC_RUN
 #include "rclcpp/rclcpp.hpp"
@@ -60,6 +61,7 @@ private Q_SLOTS:
   void updateVisualization();
 
 protected:
+  void update(float wall_dt, float ros_dt) override;
   void processMessage(const autoware_vehicle_msgs::msg::Steering::ConstSharedPtr msg_ptr) override;
   std::unique_ptr<Ogre::ColourValue> setColorDependsOnVelocity(
     const double vel_max, const double cmd_vel);
@@ -77,6 +79,7 @@ protected:
   // QImage hud_;
 
 private:
+  std::mutex mutex_;
   autoware_vehicle_msgs::msg::Steering::ConstSharedPtr last_msg_ptr_;
 };
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
@@ -24,7 +24,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/enum_property.hpp"
@@ -45,7 +45,7 @@
 namespace rviz_plugins
 {
 class SteeringAngleDisplay
-  : public rviz_common::RosTopicDisplay<autoware_vehicle_msgs::msg::Steering>
+  : public rviz_common::MessageFilterDisplay<autoware_vehicle_msgs::msg::Steering>
 {
   Q_OBJECT
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
@@ -24,7 +24,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"
-#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/ros_topic_display.hpp"
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/enum_property.hpp"
@@ -45,7 +45,7 @@
 namespace rviz_plugins
 {
 class SteeringAngleDisplay
-  : public rviz_common::MessageFilterDisplay<autoware_vehicle_msgs::msg::Steering>
+  : public rviz_common::RosTopicDisplay<autoware_vehicle_msgs::msg::Steering>
 {
   Q_OBJECT
 


### PR DESCRIPTION

Restores MFD superclass for SteeringAngle plugin. 

Moves rendering to update() function called from the Display superclass in the rendering thread. This fixes the issue.

Note that other plugins can be similarly modified.