### PR TITLE
fix: re-construct laneletMapLayer for reindex RTree

### DIFF
--- a/map/lanelet2_extension/lib/autoware_osm_parser.cpp
+++ b/map/lanelet2_extension/lib/autoware_osm_parser.cpp
@@ -29,6 +29,50 @@ namespace lanelet
 {
 namespace io_handlers
 {
+
+// non-const converter for const lanelet primitive types
+struct NonConstConverter {
+  auto operator()(const ConstPoint3d& c) {
+    return Point3d(c.id(), c.basicPoint(), c.attributes());
+  }
+
+  auto operator()(const ConstLineString3d& c) {
+    return LineString3d(c.id(), std::vector<Point3d>(c.begin(), c.end()), c.attributes());
+  }
+
+  auto operator()(const ConstLineStrings3d& cs) {
+    auto ls = LineStrings3d{};
+    ls.reserve(cs.size());
+    for (auto&& c: cs) {
+      ls.emplace_back(NonConstConverter()(c));
+    }
+    return ls;
+  }
+
+  auto operator()(const ConstInnerBounds& cs) {
+    auto ib = InnerBounds{};
+    ib.reserve(cs.size());
+    for (auto&& c: cs) {
+      ib.emplace_back(NonConstConverter()(c));
+    }
+    return ib;
+  }
+
+  auto operator()(const ConstPolygon3d& c) {
+    return Polygon3d(c.id(), std::vector<Point3d>(c.begin(), c.end()), c.attributes());
+  }
+
+  auto operator()(const ConstWeakArea& e) {
+    auto c = e.lock();
+    return WeakArea(Area(std::const_pointer_cast<AreaData>(c.constData())));
+  }
+
+  auto operator()(const ConstWeakLanelet& e) {
+    auto c = e.lock();
+    return WeakLanelet(Lanelet(std::const_pointer_cast<LaneletData>(c.constData())));
+  }
+};
+
 std::unique_ptr<LaneletMap> AutowareOsmParser::parse(
   const std::string & filename, ErrorMessages & errors) const
 {
@@ -43,6 +87,51 @@ std::unique_ptr<LaneletMap> AutowareOsmParser::parse(
       point.y() = point.attribute("local_y").asDouble().value();
     }
   }
+
+  // re-construct LaneletMapLayer
+  PointLayer::Map points;
+  LaneletLayer::Map lanelets;
+  AreaLayer::Map areas;
+  RegulatoryElementLayer::Map regulatory_elements;
+  PolygonLayer::Map polygons;
+  LineStringLayer::Map line_strings;
+
+  for(auto&& elem: map->pointLayer) {
+    points.emplace(elem.id(), Point3d(elem.id(), elem.basicPoint(), elem.attributes()));
+  }
+
+  for(const auto& elem: map->lineStringLayer) {
+    line_strings.emplace(elem.id(), LineString3d(elem.id(), std::vector<Point3d>(elem.begin(), elem.end()), elem.attributes()));
+  }
+
+  for(const auto& elem: map->polygonLayer) {
+    polygons.emplace(elem.id(), Polygon3d(elem.id(), std::vector<Point3d>(elem.begin(), elem.end()), elem.attributes()));
+  }
+
+  for(auto&& elem: map->laneletLayer) {
+    lanelets.emplace(elem.id(), Lanelet(elem.id(), elem.leftBound(), elem.rightBound(), elem.attributes(), elem.regulatoryElements()));
+  }
+
+  for(auto&& elem: map->areaLayer) {
+    areas.emplace(elem.id(), Area(elem.id(), elem.outerBound(), elem.innerBounds(), elem.attributes(), elem.regulatoryElements()));
+  }
+
+  for(auto&& elem: map->regulatoryElementLayer) {
+    auto parameterMap = RuleParameterMap{};
+    for(const auto& param: elem->getParameters()) {
+      auto rules = RuleParameters{};
+      rules.reserve(param.second.size());
+      for (auto&& p: param.second) {
+        auto v = boost::apply_visitor([](const auto& v){ return RuleParameter(NonConstConverter{}(v)); }, p);
+        rules.emplace_back(v);
+      }
+      parameterMap[param.first] = rules;
+    }
+    auto rule = elem->attributes().at(AttributeNamesString::Subtype).value();
+    regulatory_elements.emplace(elem->id(), RegulatoryElementFactory::create(rule, elem->id(), parameterMap, elem->attributes()));
+  }
+
+  map = std::make_unique<LaneletMap>(lanelets, areas, regulatory_elements, polygons, line_strings, points);
 
   // rerun align function in just in case
   for (Lanelet & lanelet : map->laneletLayer) {


### PR DESCRIPTION
## Kind of PR
- [x] Bugfix

## Abstruction
AutowareOsmParser is changed point value after RTree is constructed. https://github.com/tier4/AutowareArchitectureProposal.iv/blob/2328f517117a2f5f540ee5080a48748a1c2aa60f/map/lanelet2_extension/lib/autoware_osm_parser.cpp#L38-L45
For reindex RTree, construct LaneletMap class again after overwrite points as local one.
