### PR TITLE
Rviz overlay render in update

### DIFF
--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.cpp
@@ -51,7 +51,7 @@ ConsoleMeterDisplay::~ConsoleMeterDisplay()
 
 void ConsoleMeterDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  MFDClass::onInitialize();
   static int count = 0;
   rviz_common::UniformStringStream ss;
   ss << "ConsoleMeterDisplayObject" << count++;
@@ -62,18 +62,6 @@ void ConsoleMeterDisplay::onInitialize()
   overlay_->updateTextureSize(property_length_->getInt(), property_length_->getInt());
   overlay_->setPosition(property_left_->getInt(), property_top_->getInt());
   overlay_->setDimensions(overlay_->getTextureWidth(), overlay_->getTextureHeight());
-
-  // QColor background_color;
-  // background_color.setAlpha(0);
-  // jsk_rviz_plugins::ScopedPixelBuffer buffer = overlay_->getBuffer();
-  // hud_ = buffer.getQImage(*overlay_);
-  // for (int i = 0; i < overlay_->getTextureWidth(); i++)
-  // {
-  //   for (int j = 0; j < overlay_->getTextureHeight(); j++)
-  //   {
-  //     hud_.setPixel(i, j, background_color.rgba());
-  //   }
-  // }
 }
 
 void ConsoleMeterDisplay::onEnable()
@@ -89,14 +77,18 @@ void ConsoleMeterDisplay::onDisable()
   overlay_->hide();
 }
 
-void ConsoleMeterDisplay::processMessage(
-  const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg_ptr)
+void ConsoleMeterDisplay::update(float wall_dt, float ros_dt)
 {
-  if (!isEnabled()) {
-    return;
-  }
-  if (!overlay_->isVisible()) {
-    return;
+  (void) wall_dt;
+  (void) ros_dt;
+
+  double linear_x = 0;
+  {
+    std::lock_guard<std::mutex> message_lock(mutex_);
+    if (!last_msg_ptr_) {
+      return;
+    }
+    linear_x = last_msg_ptr_->twist.linear.x;
   }
 
   QColor background_color;
@@ -115,7 +107,7 @@ void ConsoleMeterDisplay::processMessage(
   QColor white_color(Qt::white);
   white_color.setAlpha(255);
   const float velocity_ratio = std::min(
-    std::max(std::fabs(msg_ptr->twist.linear.x) - meter_min_velocity_, 0.0) /
+    std::max(std::fabs(linear_x) - meter_min_velocity_, 0.0) /
     (meter_max_velocity_ - meter_min_velocity_),
     1.0);
   const float theta =
@@ -149,14 +141,28 @@ void ConsoleMeterDisplay::processMessage(
   font.setBold(true);
   painter.setFont(font);
   std::ostringstream velocity_ss;
-  velocity_ss << std::fixed << std::setprecision(2) << msg_ptr->twist.linear.x * 3.6 << "km/h";
+  velocity_ss << std::fixed << std::setprecision(2) << linear_x * 3.6 << "km/h";
   painter.drawText(
     0, std::min(property_value_height_offset_->getInt(), h - 1), w,
     std::max(h - property_value_height_offset_->getInt(), 1), Qt::AlignCenter | Qt::AlignVCenter,
     velocity_ss.str().c_str());
   painter.end();
-  last_msg_ptr_ = msg_ptr;
   updateVisualization();
+}
+
+void ConsoleMeterDisplay::processMessage(
+  const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg_ptr)
+{
+  if (!isEnabled()) {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> message_lock(mutex_);
+    last_msg_ptr_ = msg_ptr;
+  }
+
+  queueRender();
 }
 
 void ConsoleMeterDisplay::updateVisualization()

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.cpp
@@ -51,7 +51,7 @@ ConsoleMeterDisplay::~ConsoleMeterDisplay()
 
 void ConsoleMeterDisplay::onInitialize()
 {
-  MFDClass::onInitialize();
+  RTDClass::onInitialize();
   static int count = 0;
   rviz_common::UniformStringStream ss;
   ss << "ConsoleMeterDisplayObject" << count++;

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.hpp
@@ -15,26 +15,13 @@
 #ifndef TOOLS__CONSOLE_METER_HPP_
 #define TOOLS__CONSOLE_METER_HPP_
 
-#include <deque>
-#include <iomanip>
 #include <memory>
 
 #ifndef Q_MOC_RUN
-#include "rclcpp/rclcpp.hpp"
-#include "rviz_common/display_context.hpp"
-#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/ros_topic_display.hpp"
-#include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/color_property.hpp"
-#include "rviz_common/properties/enum_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
 #include "rviz_common/properties/int_property.hpp"
-#include "rviz_common/validate_floats.hpp"
-
-#include "OgreBillboardSet.h"
-#include "OgreManualObject.h"
-#include "OgreSceneManager.h"
-#include "OgreSceneNode.h"
 
 #include "autoware_utils/autoware_utils.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.hpp
@@ -19,7 +19,7 @@
 #include <mutex>
 
 #ifndef Q_MOC_RUN
-#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/ros_topic_display.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
 #include "rviz_common/properties/int_property.hpp"
@@ -33,7 +33,7 @@
 namespace rviz_plugins
 {
 class ConsoleMeterDisplay
-  : public rviz_common::MessageFilterDisplay<geometry_msgs::msg::TwistStamped>
+  : public rviz_common::RosTopicDisplay<geometry_msgs::msg::TwistStamped>
 {
   Q_OBJECT
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.hpp
@@ -16,9 +16,10 @@
 #define TOOLS__CONSOLE_METER_HPP_
 
 #include <memory>
+#include <mutex>
 
 #ifndef Q_MOC_RUN
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
 #include "rviz_common/properties/int_property.hpp"
@@ -32,7 +33,7 @@
 namespace rviz_plugins
 {
 class ConsoleMeterDisplay
-  : public rviz_common::RosTopicDisplay<geometry_msgs::msg::TwistStamped>
+  : public rviz_common::MessageFilterDisplay<geometry_msgs::msg::TwistStamped>
 {
   Q_OBJECT
 
@@ -48,6 +49,7 @@ private Q_SLOTS:
   void updateVisualization();
 
 protected:
+  void update(float wall_dt, float ros_dt) override;
   void processMessage(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg_ptr) override;
   jsk_rviz_plugins::OverlayObject::Ptr overlay_;
   rviz_common::properties::ColorProperty * property_text_color_;
@@ -80,6 +82,8 @@ private:
   };
   Arc inner_arc_;
   Arc outer_arc_;
+
+  std::mutex mutex_;
   geometry_msgs::msg::TwistStamped::ConstSharedPtr last_msg_ptr_;
 };
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -102,21 +102,7 @@ void SteeringAngleDisplay::onInitialize()
 
   overlay_->show();
 
-  overlay_->updateTextureSize(property_length_->getInt(), property_length_->getInt());
-  overlay_->setPosition(property_left_->getInt(), property_top_->getInt());
-  overlay_->setDimensions(overlay_->getTextureWidth(), overlay_->getTextureHeight());
-
-  // QColor background_color;
-  // background_color.setAlpha(0);
-  // jsk_rviz_plugins::ScopedPixelBuffer buffer = overlay_->getBuffer();
-  // hud_ = buffer.getQImage(*overlay_);
-  // for (int i = 0; i < overlay_->getTextureWidth(); i++)
-  // {
-  //   for (int j = 0; j < overlay_->getTextureHeight(); j++)
-  //   {
-  //     hud_.setPixel(i, j, background_color.rgba());
-  //   }
-  // }
+  updateVisualization();
 }
 
 void SteeringAngleDisplay::onEnable()
@@ -132,19 +118,24 @@ void SteeringAngleDisplay::onDisable()
   overlay_->hide();
 }
 
-void SteeringAngleDisplay::processMessage(
-  const autoware_vehicle_msgs::msg::Steering::ConstSharedPtr msg_ptr)
+void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
 {
-  if (!isEnabled()) {
-    return;
-  }
-  if (!overlay_->isVisible()) {
-    return;
+  (void) wall_dt;
+  (void) ros_dt;
+
+  {
+    std::lock_guard<std::mutex> message_lock(mutex_);
+    if (!last_msg_ptr_) {
+      return;
+    }
   }
 
   QColor background_color;
   background_color.setAlpha(0);
   jsk_rviz_plugins::ScopedPixelBuffer buffer = overlay_->getBuffer();
+  if (!buffer.getPixelBuffer())
+    return;
+
   QImage hud = buffer.getQImage(*overlay_);
   hud.fill(background_color);
 
@@ -159,7 +150,7 @@ void SteeringAngleDisplay::processMessage(
 
   QMatrix rotation_matrix;
   rotation_matrix.rotate(
-    std::round(property_handle_angle_scale_->getFloat() * (msg_ptr->data / M_PI) * -180.0));
+    std::round(property_handle_angle_scale_->getFloat() * (last_msg_ptr_->data / M_PI) * -180.0));
   // else
   // rotation_matrix.rotate
   // ((property_handle_angle_scale_->getFloat() * (msg_ptr->data / M_PI) * -180.0));
@@ -179,15 +170,28 @@ void SteeringAngleDisplay::processMessage(
   font.setBold(true);
   painter.setFont(font);
   std::ostringstream steering_angle_ss;
-  steering_angle_ss << std::fixed << std::setprecision(1) << msg_ptr->data * 180.0 / M_PI << "deg";
+  steering_angle_ss << std::fixed << std::setprecision(1) << last_msg_ptr_->data * 180.0 / M_PI << "deg";
   painter.drawText(
     0, std::min(property_value_height_offset_->getInt(), h - 1), w,
     std::max(h - property_value_height_offset_->getInt(), 1), Qt::AlignCenter | Qt::AlignVCenter,
     steering_angle_ss.str().c_str());
 
   painter.end();
-  last_msg_ptr_ = msg_ptr;
-  updateVisualization();
+}
+
+void SteeringAngleDisplay::processMessage(
+  const autoware_vehicle_msgs::msg::Steering::ConstSharedPtr msg_ptr)
+{
+  if (!isEnabled()) {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> message_lock(mutex_);
+    last_msg_ptr_ = msg_ptr;
+  }
+
+  queueRender();
 }
 
 void SteeringAngleDisplay::updateVisualization()
@@ -195,18 +199,6 @@ void SteeringAngleDisplay::updateVisualization()
   overlay_->updateTextureSize(property_length_->getInt(), property_length_->getInt());
   overlay_->setPosition(property_left_->getInt(), property_top_->getInt());
   overlay_->setDimensions(overlay_->getTextureWidth(), overlay_->getTextureHeight());
-
-  // QColor background_color;
-  // background_color.setAlpha(0);
-  // jsk_rviz_plugins::ScopedPixelBuffer buffer = overlay_->getBuffer();
-  // hud_ = buffer.getQImage(*overlay_);
-  // for (int i = 0; i < overlay_->getTextureWidth(); i++)
-  // {
-  //   for (int j = 0; j < overlay_->getTextureHeight(); j++)
-  //   {
-  //     hud_.setPixel(i, j, background_color.rgba());
-  //   }
-  // }
 }
 
 }  // namespace rviz_plugins

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -123,11 +123,13 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   (void) wall_dt;
   (void) ros_dt;
 
+  double steering = 0;
   {
     std::lock_guard<std::mutex> message_lock(mutex_);
     if (!last_msg_ptr_) {
       return;
     }
+    steering = last_msg_ptr_->data;
   }
 
   QColor background_color;
@@ -151,7 +153,8 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
 
   QMatrix rotation_matrix;
   rotation_matrix.rotate(
-    std::round(property_handle_angle_scale_->getFloat() * (last_msg_ptr_->data / M_PI) * -180.0));
+    std::round(property_handle_angle_scale_->getFloat() * (steering / M_PI) * -180.0));
+
   // else
   // rotation_matrix.rotate
   // ((property_handle_angle_scale_->getFloat() * (msg_ptr->data / M_PI) * -180.0));
@@ -171,7 +174,7 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   font.setBold(true);
   painter.setFont(font);
   std::ostringstream steering_angle_ss;
-  steering_angle_ss << std::fixed << std::setprecision(1) << last_msg_ptr_->data * 180.0 / M_PI <<
+  steering_angle_ss << std::fixed << std::setprecision(1) << steering * 180.0 / M_PI <<
     "deg";
   painter.drawText(
     0, std::min(property_value_height_offset_->getInt(), h - 1), w,

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -94,7 +94,7 @@ SteeringAngleDisplay::~SteeringAngleDisplay()
 
 void SteeringAngleDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  MFDClass::onInitialize();
   static int count = 0;
   rviz_common::UniformStringStream ss;
   ss << "SteeringAngleDisplayObject" << count++;

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -133,8 +133,9 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   QColor background_color;
   background_color.setAlpha(0);
   jsk_rviz_plugins::ScopedPixelBuffer buffer = overlay_->getBuffer();
-  if (!buffer.getPixelBuffer())
+  if (!buffer.getPixelBuffer()) {
     return;
+  }
 
   QImage hud = buffer.getQImage(*overlay_);
   hud.fill(background_color);
@@ -170,7 +171,8 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   font.setBold(true);
   painter.setFont(font);
   std::ostringstream steering_angle_ss;
-  steering_angle_ss << std::fixed << std::setprecision(1) << last_msg_ptr_->data * 180.0 / M_PI << "deg";
+  steering_angle_ss << std::fixed << std::setprecision(1) << last_msg_ptr_->data * 180.0 / M_PI <<
+    "deg";
   painter.drawText(
     0, std::min(property_value_height_offset_->getInt(), h - 1), w,
     std::max(h - property_value_height_offset_->getInt(), 1), Qt::AlignCenter | Qt::AlignVCenter,

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -63,7 +63,7 @@ SteeringAngleDisplay::~SteeringAngleDisplay()
 
 void SteeringAngleDisplay::onInitialize()
 {
-  MFDClass::onInitialize();
+  RTDClass::onInitialize();
   static int count = 0;
   rviz_common::UniformStringStream ss;
   ss << "SteeringAngleDisplayObject" << count++;

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <iomanip>
 #include <memory>
 #include <string>
 #include <algorithm>
@@ -23,38 +24,6 @@
 
 namespace rviz_plugins
 {
-std::unique_ptr<Ogre::ColourValue> SteeringAngleDisplay::gradation(
-  const QColor & color_min, const QColor & color_max, const double ratio)
-{
-  std::unique_ptr<Ogre::ColourValue> color_ptr(new Ogre::ColourValue);
-  color_ptr->g = color_max.greenF() * ratio + color_min.greenF() * (1.0 - ratio);
-  color_ptr->r = color_max.redF() * ratio + color_min.redF() * (1.0 - ratio);
-  color_ptr->b = color_max.blueF() * ratio + color_min.blueF() * (1.0 - ratio);
-
-  return color_ptr;
-}
-
-std::unique_ptr<Ogre::ColourValue> SteeringAngleDisplay::setColorDependsOnVelocity(
-  const double vel_max, const double cmd_vel)
-{
-  const double cmd_vel_abs = std::fabs(cmd_vel);
-  const double vel_min = 0.0;
-
-  std::unique_ptr<Ogre::ColourValue> color_ptr(new Ogre::ColourValue());
-  if (vel_min < cmd_vel_abs && cmd_vel_abs <= (vel_max / 2.0)) {
-    double ratio = (cmd_vel_abs - vel_min) / (vel_max / 2.0 - vel_min);
-    color_ptr = gradation(Qt::red, Qt::yellow, ratio);
-  } else if ((vel_max / 2.0) < cmd_vel_abs && cmd_vel_abs <= vel_max) {
-    double ratio = (cmd_vel_abs - vel_max / 2.0) / (vel_max - vel_max / 2.0);
-    color_ptr = gradation(Qt::yellow, Qt::green, ratio);
-  } else if (vel_max < cmd_vel_abs) {
-    *color_ptr = Ogre::ColourValue::Green;
-  } else {
-    *color_ptr = Ogre::ColourValue::Red;
-  }
-
-  return color_ptr;
-}
 
 SteeringAngleDisplay::SteeringAngleDisplay()
 : handle_image_(

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
@@ -18,6 +18,7 @@
 #include <deque>
 #include <iomanip>
 #include <memory>
+#include <mutex>
 
 #ifndef Q_MOC_RUN
 #include "rclcpp/rclcpp.hpp"
@@ -60,6 +61,7 @@ private Q_SLOTS:
   void updateVisualization();
 
 protected:
+  void update(float wall_dt, float ros_dt) override;
   void processMessage(const autoware_vehicle_msgs::msg::Steering::ConstSharedPtr msg_ptr) override;
   std::unique_ptr<Ogre::ColourValue> setColorDependsOnVelocity(
     const double vel_max, const double cmd_vel);
@@ -77,6 +79,7 @@ protected:
   // QImage hud_;
 
 private:
+  std::mutex mutex_;
   autoware_vehicle_msgs::msg::Steering::ConstSharedPtr last_msg_ptr_;
 };
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
@@ -24,7 +24,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/enum_property.hpp"
@@ -45,7 +45,7 @@
 namespace rviz_plugins
 {
 class SteeringAngleDisplay
-  : public rviz_common::RosTopicDisplay<autoware_vehicle_msgs::msg::Steering>
+  : public rviz_common::MessageFilterDisplay<autoware_vehicle_msgs::msg::Steering>
 {
   Q_OBJECT
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
@@ -15,27 +15,14 @@
 #ifndef TOOLS__STEERING_ANGLE_HPP_
 #define TOOLS__STEERING_ANGLE_HPP_
 
-#include <deque>
-#include <iomanip>
 #include <memory>
 #include <mutex>
 
 #ifndef Q_MOC_RUN
-#include "rclcpp/rclcpp.hpp"
-#include "rviz_common/display_context.hpp"
-#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/message_filter_display.hpp"
-#include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/color_property.hpp"
-#include "rviz_common/properties/enum_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
 #include "rviz_common/properties/int_property.hpp"
-#include "rviz_common/validate_floats.hpp"
-
-#include "OgreBillboardSet.h"
-#include "OgreManualObject.h"
-#include "OgreSceneManager.h"
-#include "OgreSceneNode.h"
 
 #include "autoware_vehicle_msgs/msg/steering.hpp"
 
@@ -63,10 +50,7 @@ private Q_SLOTS:
 protected:
   void update(float wall_dt, float ros_dt) override;
   void processMessage(const autoware_vehicle_msgs::msg::Steering::ConstSharedPtr msg_ptr) override;
-  std::unique_ptr<Ogre::ColourValue> setColorDependsOnVelocity(
-    const double vel_max, const double cmd_vel);
-  std::unique_ptr<Ogre::ColourValue> gradation(
-    const QColor & color_min, const QColor & color_max, const double ratio);
+
   jsk_rviz_plugins::OverlayObject::Ptr overlay_;
   rviz_common::properties::ColorProperty * property_text_color_;
   rviz_common::properties::IntProperty * property_left_;

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/steering_angle.hpp
@@ -19,7 +19,7 @@
 #include <mutex>
 
 #ifndef Q_MOC_RUN
-#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/ros_topic_display.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
 #include "rviz_common/properties/int_property.hpp"
@@ -32,7 +32,7 @@
 namespace rviz_plugins
 {
 class SteeringAngleDisplay
-  : public rviz_common::MessageFilterDisplay<autoware_vehicle_msgs::msg::Steering>
+  : public rviz_common::RosTopicDisplay<autoware_vehicle_msgs::msg::Steering>
 {
   Q_OBJECT
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/turn_signal.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/turn_signal.cpp
@@ -45,7 +45,7 @@ TurnSignalDisplay::~TurnSignalDisplay()
 
 void TurnSignalDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  MFDClass::onInitialize();
   static int count = 0;
   rviz_common::UniformStringStream ss;
   ss << "TurnSignalDisplayObject" << count++;
@@ -77,8 +77,27 @@ void TurnSignalDisplay::processMessage(
   if (!isEnabled()) {
     return;
   }
-  if (!overlay_->isVisible()) {
-    return;
+
+  {
+    std::lock_guard<std::mutex> message_lock(mutex_);
+    last_msg_ptr_ = msg_ptr;
+  }
+
+  queueRender();
+}
+
+void TurnSignalDisplay::update(float wall_dt, float ros_dt)
+{
+  (void) wall_dt;
+  (void) ros_dt;
+
+  unsigned int signal_type;
+  {
+    std::lock_guard<std::mutex> message_lock(mutex_);
+    if (!last_msg_ptr_) {
+      return;
+    }
+    signal_type = last_msg_ptr_->data;
   }
 
   QColor background_color;
@@ -93,19 +112,19 @@ void TurnSignalDisplay::processMessage(
   // turn signal color
   QColor white_color(Qt::white);
   white_color.setAlpha(255);
-  if (msg_ptr->data == autoware_vehicle_msgs::msg::TurnSignal::RIGHT) {
+  if (signal_type == autoware_vehicle_msgs::msg::TurnSignal::RIGHT) {
     painter.setPen(QPen(white_color, static_cast<int>(2), Qt::DotLine));
     painter.drawPolygon(left_arrow_polygon_, 7);
     painter.setBrush(QBrush(Qt::white, Qt::SolidPattern));
     painter.setPen(QPen(white_color, static_cast<int>(2), Qt::SolidLine));
     painter.drawPolygon(right_arrow_polygon_, 7);
-  } else if (msg_ptr->data == autoware_vehicle_msgs::msg::TurnSignal::LEFT) {
+  } else if (signal_type == autoware_vehicle_msgs::msg::TurnSignal::LEFT) {
     painter.setPen(QPen(white_color, static_cast<int>(2), Qt::DotLine));
     painter.drawPolygon(right_arrow_polygon_, 7);
     painter.setBrush(QBrush(Qt::white, Qt::SolidPattern));
     painter.setPen(QPen(white_color, static_cast<int>(2), Qt::SolidLine));
     painter.drawPolygon(left_arrow_polygon_, 7);
-  } else if (msg_ptr->data == autoware_vehicle_msgs::msg::TurnSignal::HAZARD) {
+  } else if (signal_type == autoware_vehicle_msgs::msg::TurnSignal::HAZARD) {
     painter.setBrush(QBrush(Qt::white, Qt::SolidPattern));
     painter.setPen(QPen(white_color, static_cast<int>(2), Qt::SolidLine));
     painter.drawPolygon(right_arrow_polygon_, 7);
@@ -116,7 +135,6 @@ void TurnSignalDisplay::processMessage(
     painter.drawPolygon(left_arrow_polygon_, 7);
   }
   painter.end();
-  last_msg_ptr_ = msg_ptr;
   updateVisualization();
 }
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/turn_signal.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/turn_signal.cpp
@@ -45,7 +45,7 @@ TurnSignalDisplay::~TurnSignalDisplay()
 
 void TurnSignalDisplay::onInitialize()
 {
-  MFDClass::onInitialize();
+  RTDClass::onInitialize();
   static int count = 0;
   rviz_common::UniformStringStream ss;
   ss << "TurnSignalDisplayObject" << count++;

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/turn_signal.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/turn_signal.hpp
@@ -15,25 +15,11 @@
 #ifndef TOOLS__TURN_SIGNAL_HPP_
 #define TOOLS__TURN_SIGNAL_HPP_
 
-#include <deque>
 #include <memory>
 
 #ifndef Q_MOC_RUN
-#include "rclcpp/rclcpp.hpp"
-#include "rviz_common/display_context.hpp"
-#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/ros_topic_display.hpp"
-#include "rviz_common/properties/bool_property.hpp"
-#include "rviz_common/properties/color_property.hpp"
-#include "rviz_common/properties/enum_property.hpp"
-#include "rviz_common/properties/float_property.hpp"
 #include "rviz_common/properties/int_property.hpp"
-#include "rviz_common/validate_floats.hpp"
-
-#include "OgreBillboardSet.h"
-#include "OgreManualObject.h"
-#include "OgreSceneManager.h"
-#include "OgreSceneNode.h"
 
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/turn_signal.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/turn_signal.hpp
@@ -19,7 +19,7 @@
 #include <mutex>
 
 #ifndef Q_MOC_RUN
-#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/ros_topic_display.hpp"
 #include "rviz_common/properties/int_property.hpp"
 
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
@@ -30,7 +30,7 @@
 namespace rviz_plugins
 {
 class TurnSignalDisplay
-  : public rviz_common::MessageFilterDisplay<autoware_vehicle_msgs::msg::TurnSignal>
+  : public rviz_common::RosTopicDisplay<autoware_vehicle_msgs::msg::TurnSignal>
 {
   Q_OBJECT
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/turn_signal.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/turn_signal.hpp
@@ -16,9 +16,10 @@
 #define TOOLS__TURN_SIGNAL_HPP_
 
 #include <memory>
+#include <mutex>
 
 #ifndef Q_MOC_RUN
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/properties/int_property.hpp"
 
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
@@ -29,7 +30,7 @@
 namespace rviz_plugins
 {
 class TurnSignalDisplay
-  : public rviz_common::RosTopicDisplay<autoware_vehicle_msgs::msg::TurnSignal>
+  : public rviz_common::MessageFilterDisplay<autoware_vehicle_msgs::msg::TurnSignal>
 {
   Q_OBJECT
 
@@ -45,6 +46,7 @@ private Q_SLOTS:
   void updateVisualization();
 
 protected:
+  void update(float wall_dt, float ros_dt) override;
   void processMessage(
     const autoware_vehicle_msgs::msg::TurnSignal::ConstSharedPtr msg_ptr) override;
   jsk_rviz_plugins::OverlayObject::Ptr overlay_;
@@ -57,6 +59,8 @@ protected:
 private:
   QPointF right_arrow_polygon_[7];
   QPointF left_arrow_polygon_[7];
+
+  std::mutex mutex_;
   autoware_vehicle_msgs::msg::TurnSignal::ConstSharedPtr last_msg_ptr_;
 };
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.cpp
@@ -15,6 +15,8 @@
 #include <memory>
 #include <algorithm>
 
+#include "OgreMaterialManager.h"
+
 #include "velocity_history.hpp"
 #define EIGEN_MPL2_ONLY
 #include "Eigen/Core"

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.cpp
@@ -88,7 +88,7 @@ VelocityHistoryDisplay::~VelocityHistoryDisplay()
 
 void VelocityHistoryDisplay::onInitialize()
 {
-  MFDClass::onInitialize();
+  RTDClass::onInitialize();
 
   velocity_manual_object_ = scene_manager_->createManualObject();
   velocity_manual_object_->setDynamic(true);
@@ -97,7 +97,7 @@ void VelocityHistoryDisplay::onInitialize()
 
 void VelocityHistoryDisplay::reset()
 {
-  MFDClass::reset();
+  RTDClass::reset();
   velocity_manual_object_->clear();
 }
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.hpp
@@ -23,7 +23,7 @@
 #include "OgreColourValue.h"
 #include "OgreManualObject.h"
 #include "OgreVector3.h"
-#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/ros_topic_display.hpp"
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
@@ -35,7 +35,7 @@
 namespace rviz_plugins
 {
 class VelocityHistoryDisplay
-  : public rviz_common::MessageFilterDisplay<geometry_msgs::msg::TwistStamped>
+  : public rviz_common::RosTopicDisplay<geometry_msgs::msg::TwistStamped>
 {
   Q_OBJECT
 

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.hpp
@@ -19,18 +19,12 @@
 #include <memory>
 #include <tuple>
 
-#include "OgreBillboardSet.h"
+#include "OgreColourValue.h"
 #include "OgreManualObject.h"
-#include "OgreMaterialManager.h"
-#include "OgreSceneManager.h"
-#include "OgreSceneNode.h"
-#include "rclcpp/rclcpp.hpp"
-#include "rviz_common/display_context.hpp"
-#include "rviz_common/frame_manager_iface.hpp"
+#include "OgreVector3.h"
 #include "rviz_common/ros_topic_display.hpp"
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/color_property.hpp"
-#include "rviz_common/properties/enum_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
 #include "rviz_common/properties/parse_color.hpp"
 #include "rviz_common/validate_floats.hpp"

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.hpp
@@ -17,12 +17,13 @@
 
 #include <deque>
 #include <memory>
+#include <mutex>
 #include <tuple>
 
 #include "OgreColourValue.h"
 #include "OgreManualObject.h"
 #include "OgreVector3.h"
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
@@ -34,7 +35,7 @@
 namespace rviz_plugins
 {
 class VelocityHistoryDisplay
-  : public rviz_common::RosTopicDisplay<geometry_msgs::msg::TwistStamped>
+  : public rviz_common::MessageFilterDisplay<geometry_msgs::msg::TwistStamped>
 {
   Q_OBJECT
 
@@ -49,6 +50,7 @@ private Q_SLOTS:
   void updateVisualization();
 
 protected:
+  void update(float wall_dt, float ros_dt) override;
   void processMessage(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg_ptr) override;
   std::unique_ptr<Ogre::ColourValue> setColorDependsOnVelocity(
     const double vel_max, const double cmd_vel);
@@ -66,6 +68,7 @@ private:
   std::deque<std::tuple<geometry_msgs::msg::TwistStamped::ConstSharedPtr, Ogre::Vector3>>
   histories_;
   bool validateFloats(const geometry_msgs::msg::TwistStamped::ConstSharedPtr & msg_ptr);
+  std::mutex mutex_;
 };
 
 }  // namespace rviz_plugins


### PR DESCRIPTION
#461 changes applied to other plugins as well. Apply once 461 is merged.
Also, includes a bit of cleaning (removed a bunch of unnecessary includes and some dead code).

Note that there is a high degree of code repetition in the package (between different plugins) and perhaps it would be good to address that (with a dedicated superclass, utils and similar).