### PR TITLE
🐞fix(pointcloud_map_loader): load error path

### DIFF
--- a/map/map_loader/src/pointcloud_map_loader/main.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/main.cpp
@@ -43,6 +43,12 @@ int main(int argc, char * argv[])
 
   std::vector<std::string> pcd_paths;
   for (int i = 1; i < argc; ++i) {
+    const char* tmp_prm = "/tmp/launch_params_";
+    if((strlen(argv[i]) > strlen(tmp_prm)) && (NULL != strstr(argv[i], tmp_prm)))
+    {
+      continue;
+    }
+
     const fs::path arg(argv[i]);
 
     if (!fs::exists(arg)) {


### PR DESCRIPTION
load error on args "/tmp/launch_params_*"

## PRの種類

- [ ] 新機能
- [ ] 既存機能の性能向上
- [x] バグフィックス

## Jiraリンク

## 変更概要

As `pointcloud_map_loader` node launched with params `--params-file /tmp/launch_params_lw_rc9_e` , we got a error:

```
[pointcloud_map_loader-20] [ERROR] [1618541063.027592726] [map.pointcloud_map_loader]: PCD load failed: /tmp/launch_params_lw_rc9_e
```

This param file shoud not loaded as normal pcd files.

## レビュー方法

Check the prefix of pcd file with `/tmp/launch_params_` before load pcd files.

## その他

- [ ] [リリースノート](https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416)への記載
