### PR TITLE
port part of external_cmd_selector

### DIFF
--- a/control/external_cmd_selector/include/external_cmd_selector/external_cmd_selector_node.hpp
+++ b/control/external_cmd_selector/include/external_cmd_selector/external_cmd_selector_node.hpp
@@ -20,6 +20,8 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
+#include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
+#include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <autoware_control_msgs/msg/external_command_selector_mode.hpp>
 #include <autoware_control_msgs/srv/external_command_select.hpp>
 #include <autoware_external_api_msgs/msg/control_command_stamped.hpp>
@@ -40,7 +42,8 @@ private:
   using CommandSourceSelect = autoware_control_msgs::srv::ExternalCommandSelect;
   using CommandSourceMode = autoware_control_msgs::msg::ExternalCommandSelectorMode;
   using InternalGearShift = autoware_auto_vehicle_msgs::msg::GearCommand;
-  using InternalTurnSignal = autoware_vehicle_msgs::msg::TurnSignal;
+  using InternalTurnSignal = autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand;
+  using InternalHazardSignal = autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
   using InternalHeartbeat = autoware_external_api_msgs::msg::Heartbeat;
   using ExternalControlCommand = autoware_external_api_msgs::msg::ControlCommandStamped;
   using ExternalGearShift = autoware_external_api_msgs::msg::GearShiftStamped;
@@ -56,6 +59,7 @@ private:
   rclcpp::Publisher<ExternalControlCommand>::SharedPtr pub_control_cmd_;
   rclcpp::Publisher<InternalGearShift>::SharedPtr pub_shift_cmd_;
   rclcpp::Publisher<InternalTurnSignal>::SharedPtr pub_turn_signal_cmd_;
+  rclcpp::Publisher<InternalHazardSignal>::SharedPtr pub_hazard_signal_cmd_;
   rclcpp::Publisher<InternalHeartbeat>::SharedPtr pub_heartbeat_;
 
   // Subscriber
@@ -94,7 +98,6 @@ private:
 
   // Converter
   static InternalGearShift convert(const ExternalGearShift & command);
-  static InternalTurnSignal convert(const ExternalTurnSignal & command);
   static InternalHeartbeat convert(const ExternalHeartbeat & command);
 
   // Diagnostics Updater

--- a/control/external_cmd_selector/include/external_cmd_selector/external_cmd_selector_node.hpp
+++ b/control/external_cmd_selector/include/external_cmd_selector/external_cmd_selector_node.hpp
@@ -20,8 +20,8 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
-#include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
+#include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <autoware_control_msgs/msg/external_command_selector_mode.hpp>
 #include <autoware_control_msgs/srv/external_command_select.hpp>
 #include <autoware_external_api_msgs/msg/control_command_stamped.hpp>

--- a/control/external_cmd_selector/include/external_cmd_selector/external_cmd_selector_node.hpp
+++ b/control/external_cmd_selector/include/external_cmd_selector/external_cmd_selector_node.hpp
@@ -19,6 +19,7 @@
 #include <diagnostic_updater/update_functions.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_control_msgs/msg/external_command_selector_mode.hpp>
 #include <autoware_control_msgs/srv/external_command_select.hpp>
 #include <autoware_external_api_msgs/msg/control_command_stamped.hpp>
@@ -38,7 +39,7 @@ public:
 private:
   using CommandSourceSelect = autoware_control_msgs::srv::ExternalCommandSelect;
   using CommandSourceMode = autoware_control_msgs::msg::ExternalCommandSelectorMode;
-  using InternalGearShift = autoware_vehicle_msgs::msg::ShiftStamped;
+  using InternalGearShift = autoware_auto_vehicle_msgs::msg::GearCommand;
   using InternalTurnSignal = autoware_vehicle_msgs::msg::TurnSignal;
   using InternalHeartbeat = autoware_external_api_msgs::msg::Heartbeat;
   using ExternalControlCommand = autoware_external_api_msgs::msg::ControlCommandStamped;

--- a/control/external_cmd_selector/package.xml
+++ b/control/external_cmd_selector/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_external_api_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>

--- a/control/external_cmd_selector/package.xml
+++ b/control/external_cmd_selector/package.xml
@@ -12,6 +12,7 @@
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_external_api_msgs</depend>
+  <depend>autoware_iv_auto_msgs_converter</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>

--- a/control/external_cmd_selector/src/external_cmd_selector/external_cmd_selector_node.cpp
+++ b/control/external_cmd_selector/src/external_cmd_selector/external_cmd_selector_node.cpp
@@ -129,7 +129,9 @@ void ExternalCmdSelector::onLocalTurnSignalCmd(const ExternalTurnSignal::ConstSh
   if (current_selector_mode_.data != CommandSourceMode::LOCAL) {
     return;
   }
-  pub_turn_signal_cmd_->publish(convert(*msg));
+  auto light_signal = autoware_iv_auto_msgs_converter::convert(*msg);
+  pub_turn_signal_cmd_->publish(light_signal.turn_signal);
+  pub_hazard_signal_cmd_->publish(light_signal.hazard_signal);
 }
 
 void ExternalCmdSelector::onLocalHeartbeat(const ExternalHeartbeat::ConstSharedPtr msg)
@@ -161,7 +163,9 @@ void ExternalCmdSelector::onRemoteTurnSignalCmd(const ExternalTurnSignal::ConstS
   if (current_selector_mode_.data != CommandSourceMode::REMOTE) {
     return;
   }
-  pub_turn_signal_cmd_->publish(convert(*msg));
+  auto light_signal = autoware_iv_auto_msgs_converter::convert(*msg);
+  pub_turn_signal_cmd_->publish(light_signal.turn_signal);
+  pub_hazard_signal_cmd_->publish(light_signal.hazard_signal);
 }
 
 void ExternalCmdSelector::onRemoteHeartbeat(const ExternalHeartbeat::ConstSharedPtr msg)
@@ -187,17 +191,7 @@ void ExternalCmdSelector::onTimer() { pub_current_selector_mode_->publish(curren
 ExternalCmdSelector::InternalGearShift ExternalCmdSelector::convert(
   const ExternalGearShift & command)
 {
-  return convert(command);
-}
-
-ExternalCmdSelector::InternalTurnSignal ExternalCmdSelector::convert(
-  const ExternalTurnSignal & command)
-{
-  InternalTurnSignal message;
-  message.header.stamp = command.stamp;
-  message.header.frame_id = "base_link";  // dummy
-  message.data = command.turn_signal.data;
-  return message;
+  return autoware_iv_auto_msgs_converter::convert(command);
 }
 
 ExternalCmdSelector::InternalHeartbeat ExternalCmdSelector::convert(

--- a/control/external_cmd_selector/src/external_cmd_selector/external_cmd_selector_node.cpp
+++ b/control/external_cmd_selector/src/external_cmd_selector/external_cmd_selector_node.cpp
@@ -186,9 +186,8 @@ ExternalCmdSelector::InternalGearShift ExternalCmdSelector::convert(
   const ExternalGearShift & command)
 {
   InternalGearShift message;
-  message.header.stamp = command.stamp;
-  message.header.frame_id = "base_link";  // dummy
-  message.shift.data = command.gear_shift.data;
+  message.stamp = command.stamp;
+  message.command = command.gear_shift.data;
   return message;
 }
 

--- a/control/external_cmd_selector/src/external_cmd_selector/external_cmd_selector_node.cpp
+++ b/control/external_cmd_selector/src/external_cmd_selector/external_cmd_selector_node.cpp
@@ -14,6 +14,8 @@
 
 #include "external_cmd_selector/external_cmd_selector_node.hpp"
 
+#include <autoware_iv_auto_msgs_converter/autoware_iv_auto_msgs_converter.hpp>
+
 #include <chrono>
 #include <memory>
 #include <string>
@@ -185,10 +187,7 @@ void ExternalCmdSelector::onTimer() { pub_current_selector_mode_->publish(curren
 ExternalCmdSelector::InternalGearShift ExternalCmdSelector::convert(
   const ExternalGearShift & command)
 {
-  InternalGearShift message;
-  message.stamp = command.stamp;
-  message.command = command.gear_shift.data;
-  return message;
+  return convert(command);
 }
 
 ExternalCmdSelector::InternalTurnSignal ExternalCmdSelector::convert(


### PR DESCRIPTION
Signed-off-by: kosuke murakami <kosuke.murakami@tier4.jp>

## Description
Depends on this pr https://github.com/tier4/autoware_iv_msgs/pull/64

port
- [x]  autoware_vehicle_msgs::msg::ShiftStamped -> autoware_auto_vehicle_msgs::msg::GearCommand
- [x]  autoware_vehicle_msgs::msg::TurnSignal

pending since there are no compatible msgs in autoware.auto
- [ ]  autoware_control_msgs::srv::ExternalCommandSelect
- [ ]  autoware_control_msgs::msg::ExternalCommandSelectorMode
- [ ]  autoware_external_api_msgs::msg::Heartbeat,
- [ ]  autoware_external_api_msgs::msg::ControlCommandStamped,
- [ ]  autoware_external_api_msgs::msg::GearShiftStamped,
- [ ]  autoware_external_api_msgs::msg::TurnSignalStamped,
- [ ]  autoware_external_api_msgs::msg::Heartbeat,

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
