### PR TITLE
[autoware state monitor] support autoware.auto msg

### DIFF
--- a/system/autoware_state_monitor/Readme.md
+++ b/system/autoware_state_monitor/Readme.md
@@ -1,0 +1,56 @@
+# autoware_state_monitor
+
+## Purpose
+
+This node manages AutowareState transitions.
+
+## Inner-workings / Algorithms
+
+## Inputs / Outputs
+
+### Input
+
+  <arg name="input_autoware_engage" default="/api/autoware/get/engage" />
+  <arg name="input_vehicle_state_report" default="/vehicle/state_report" />
+  <arg name="input_hazard_status" default="/system/emergency/hazard_status" />
+  <arg name="input_route" default="/planning/mission_planning/route" />
+
+  <!-- Output -->
+  <arg name="output_autoware_state" default="/autoware/state" />
+  <arg name="output_autoware_engage" default="/autoware/engage" />
+
+| Name                              | Type                                                  | Description                                       |
+| --------------------------------- | ----------------------------------------------------- | ------------------------------------------------- |
+| `/system/emergency/hazard_status` | `autoware_auto_system_msgs::msg::HazardStatusStamped` | Used to check autoware is emergency state or not  |
+| `/planning/mission_planning/rout` | `autoware_auto_planning_msgs::msg::Route`             | Subscribe route                                   |
+| `/localization/ekf_odom`          | `nav_msgs::msg::Odometry`                             | Used to decide whether vehicle is stopped or not  |
+| `/vehicle/state_report`           | `autoware_auto_vehicle_msgs::msg::VehicleStateReport` | Used to check vehicle mode: autonomous or manual. |
+
+### Output
+
+| Name               | Type                                                    | Description                                        |
+| ------------------ | ------------------------------------------------------- | -------------------------------------------------- |
+| `/autoware/engage` | `autoware_auto_system_msgs::msg::EmergencyStateStamped` | publish AutowareState                              |
+| `/autoware/state`  | `autoware_auto_system_msgs::msg::AutowareState`         | publish disengage flag on AutowareState transition |
+
+## Parameters
+
+### Node Parameters
+
+| Name          | Type | Default Value | Explanation            |
+| ------------- | ---- | ------------- | ---------------------- |
+| `update_rate` | int  | `10`          | Timer callback period. |
+
+### Core Parameters
+
+| Name                      | Type   | Default Value | Explanation                                                                |
+| ------------------------- | ------ | ------------- | -------------------------------------------------------------------------- |
+| `th_arrived_distance_m`   | double | 1.0           | threshold distance to check if vehicle has arrived at the route's endpoint |
+| `th_stopped_time_sec`     | double | 1.0           | threshold time to check if vehicle is stopped                              |
+| `th_stopped_velocity_mps` | double | 0.01          | threshold velocity to check if vehicle is stopped                          |
+| `disengage_on_route`      | bool   | true          | send diengage flag or not when the route is subscribed                     |
+| `disengage_on_goal`       | bool   | true          | send diengage flag or not when the vehicle is arrived goal                 |
+
+## Assumptions / Known limits
+
+TBD.

--- a/system/autoware_state_monitor/Readme.md
+++ b/system/autoware_state_monitor/Readme.md
@@ -10,18 +10,8 @@ This node manages AutowareState transitions.
 
 ### Input
 
-  <arg name="input_autoware_engage" default="/api/autoware/get/engage" />
-  <arg name="input_vehicle_state_report" default="/vehicle/state_report" />
-  <arg name="input_hazard_status" default="/system/emergency/hazard_status" />
-  <arg name="input_route" default="/planning/mission_planning/route" />
-
-  <!-- Output -->
-  <arg name="output_autoware_state" default="/autoware/state" />
-  <arg name="output_autoware_engage" default="/autoware/engage" />
-
 | Name                              | Type                                                  | Description                                       |
 | --------------------------------- | ----------------------------------------------------- | ------------------------------------------------- |
-| `/system/emergency/hazard_status` | `autoware_auto_system_msgs::msg::HazardStatusStamped` | Used to check autoware is emergency state or not  |
 | `/planning/mission_planning/rout` | `autoware_auto_planning_msgs::msg::Route`             | Subscribe route                                   |
 | `/localization/ekf_odom`          | `nav_msgs::msg::Odometry`                             | Used to decide whether vehicle is stopped or not  |
 | `/vehicle/state_report`           | `autoware_auto_vehicle_msgs::msg::VehicleStateReport` | Used to check vehicle mode: autonomous or manual. |

--- a/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state.hpp
+++ b/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state.hpp
@@ -26,7 +26,6 @@ enum class AutowareState : int8_t {
   WaitingForEngage,
   Driving,
   ArrivedGoal,
-  Emergency,
   Finalizing,
 };
 
@@ -52,11 +51,6 @@ inline AutowareState fromMsg(const int state)
   if (state == StateMessage::ARRIVED_GOAL) {
     return AutowareState::ArrivedGoal;
   }
-  /*
-  if (state == StateMessage::EMERGENCY) {
-    return AutowareState::Emergency;
-  }
-  */
   if (state == StateMessage::FINALIZING) {
     return AutowareState::Finalizing;
   }
@@ -86,11 +80,6 @@ inline int toMsg(const AutowareState & state)
   if (state == AutowareState::ArrivedGoal) {
     return StateMessage::ARRIVED_GOAL;
   }
-  /*
-  if (state == AutowareState::Emergency) {
-    return StateMessage::EMERGENCY;
-  }
-  */
   if (state == AutowareState::Finalizing) {
     return StateMessage::FINALIZING;
   }

--- a/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state.hpp
+++ b/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE_STATE_MONITOR__AUTOWARE_STATE_HPP_
 #define AUTOWARE_STATE_MONITOR__AUTOWARE_STATE_HPP_
 
-#include <autoware_system_msgs/msg/autoware_state.hpp>
+#include <autoware_auto_system_msgs/msg/autoware_state.hpp>
 
 #include <string>
 
@@ -30,11 +30,11 @@ enum class AutowareState : int8_t {
   Finalizing,
 };
 
-inline AutowareState fromString(const std::string & state)
+inline AutowareState fromMsg(const int state)
 {
-  using StateMessage = autoware_system_msgs::msg::AutowareState;
+  using StateMessage = autoware_auto_system_msgs::msg::AutowareState;
 
-  if (state == StateMessage::INITIALIZING_VEHICLE) {
+  if (state == StateMessage::INITIALIZING) {
     return AutowareState::InitializingVehicle;
   }
   if (state == StateMessage::WAITING_FOR_ROUTE) {
@@ -49,12 +49,14 @@ inline AutowareState fromString(const std::string & state)
   if (state == StateMessage::DRIVING) {
     return AutowareState::Driving;
   }
-  if (state == StateMessage::ARRIVAL_GOAL) {
+  if (state == StateMessage::ARRIVED_GOAL) {
     return AutowareState::ArrivedGoal;
   }
+  /*
   if (state == StateMessage::EMERGENCY) {
     return AutowareState::Emergency;
   }
+  */
   if (state == StateMessage::FINALIZING) {
     return AutowareState::Finalizing;
   }
@@ -62,12 +64,12 @@ inline AutowareState fromString(const std::string & state)
   throw std::runtime_error("invalid state");
 }
 
-inline std::string toString(const AutowareState & state)
+inline int toMsg(const AutowareState & state)
 {
-  using StateMessage = autoware_system_msgs::msg::AutowareState;
+  using StateMessage = autoware_auto_system_msgs::msg::AutowareState;
 
   if (state == AutowareState::InitializingVehicle) {
-    return StateMessage::INITIALIZING_VEHICLE;
+    return StateMessage::INITIALIZING;
   }
   if (state == AutowareState::WaitingForRoute) {
     return StateMessage::WAITING_FOR_ROUTE;
@@ -82,11 +84,13 @@ inline std::string toString(const AutowareState & state)
     return StateMessage::DRIVING;
   }
   if (state == AutowareState::ArrivedGoal) {
-    return StateMessage::ARRIVAL_GOAL;
+    return StateMessage::ARRIVED_GOAL;
   }
+  /*
   if (state == AutowareState::Emergency) {
     return StateMessage::EMERGENCY;
   }
+  */
   if (state == AutowareState::Finalizing) {
     return StateMessage::FINALIZING;
   }

--- a/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state_monitor_node.hpp
+++ b/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state_monitor_node.hpp
@@ -23,14 +23,14 @@
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
-#include <autoware_planning_msgs/msg/route.hpp>
-#include <autoware_planning_msgs/msg/trajectory.hpp>
-#include <autoware_system_msgs/msg/autoware_state.hpp>
-#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
-#include <autoware_vehicle_msgs/msg/control_mode.hpp>
-#include <autoware_vehicle_msgs/msg/engage.hpp>
+#include <autoware_auto_planning_msgs/msg/route.hpp>
+#include <autoware_auto_planning_msgs/msg/trajectory.hpp>
+#include <autoware_auto_system_msgs/msg/autoware_state.hpp>
+#include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
+#include <autoware_auto_vehicle_msgs/msg/engage.hpp>
+#include <autoware_auto_vehicle_msgs/msg/vehicle_state_report.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
-#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -66,18 +66,21 @@ private:
   rclcpp::CallbackGroup::SharedPtr callback_group_services_;
 
   // Subscriber
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::Engage>::SharedPtr sub_autoware_engage_;
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::ControlMode>::SharedPtr
-    sub_vehicle_control_mode_;
-  rclcpp::Subscription<autoware_system_msgs::msg::HazardStatusStamped>::SharedPtr sub_hazard_status;
-  rclcpp::Subscription<autoware_planning_msgs::msg::Route>::SharedPtr sub_route_;
-  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_twist_;
+  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::Engage>::SharedPtr sub_autoware_engage_;
+  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VehicleStateReport>::SharedPtr
+    sub_vehicle_state_report_;
+  rclcpp::Subscription<autoware_auto_system_msgs::msg::HazardStatusStamped>::SharedPtr
+    sub_hazard_status;
+  rclcpp::Subscription<autoware_auto_planning_msgs::msg::Route>::SharedPtr sub_route_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
 
-  void onAutowareEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
-  void onVehicleControlMode(const autoware_vehicle_msgs::msg::ControlMode::ConstSharedPtr msg);
-  void onHazardStatus(const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
-  void onRoute(const autoware_planning_msgs::msg::Route::ConstSharedPtr msg);
-  void onTwist(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
+  void onAutowareEngage(const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
+  void onVehicleVehicleStateReport(
+    const autoware_auto_vehicle_msgs::msg::VehicleStateReport::ConstSharedPtr msg);
+  void onHazardStatus(
+    const autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
+  void onRoute(const autoware_auto_planning_msgs::msg::Route::ConstSharedPtr msg);
+  void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
 
   // Topic Buffer
   void onTopic(
@@ -103,8 +106,8 @@ private:
     std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
   // Publisher
-  rclcpp::Publisher<autoware_system_msgs::msg::AutowareState>::SharedPtr pub_autoware_state_;
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::Engage>::SharedPtr pub_autoware_engage_;
+  rclcpp::Publisher<autoware_auto_system_msgs::msg::AutowareState>::SharedPtr pub_autoware_state_;
+  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::Engage>::SharedPtr pub_autoware_engage_;
 
   bool isEngaged();
   void setDisengage();

--- a/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state_monitor_node.hpp
+++ b/system/autoware_state_monitor/include/autoware_state_monitor/autoware_state_monitor_node.hpp
@@ -26,7 +26,6 @@
 #include <autoware_auto_planning_msgs/msg/route.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
-#include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
 #include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <autoware_auto_vehicle_msgs/msg/vehicle_state_report.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -69,16 +68,12 @@ private:
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::Engage>::SharedPtr sub_autoware_engage_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VehicleStateReport>::SharedPtr
     sub_vehicle_state_report_;
-  rclcpp::Subscription<autoware_auto_system_msgs::msg::HazardStatusStamped>::SharedPtr
-    sub_hazard_status;
   rclcpp::Subscription<autoware_auto_planning_msgs::msg::Route>::SharedPtr sub_route_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
 
   void onAutowareEngage(const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
   void onVehicleVehicleStateReport(
     const autoware_auto_vehicle_msgs::msg::VehicleStateReport::ConstSharedPtr msg);
-  void onHazardStatus(
-    const autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
   void onRoute(const autoware_auto_planning_msgs::msg::Route::ConstSharedPtr msg);
   void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
 

--- a/system/autoware_state_monitor/include/autoware_state_monitor/state_machine.hpp
+++ b/system/autoware_state_monitor/include/autoware_state_monitor/state_machine.hpp
@@ -21,14 +21,14 @@
 
 #include <rclcpp/time.hpp>
 
-#include <autoware_planning_msgs/msg/route.hpp>
-#include <autoware_planning_msgs/msg/trajectory.hpp>
-#include <autoware_system_msgs/msg/autoware_state.hpp>
-#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
-#include <autoware_vehicle_msgs/msg/control_mode.hpp>
-#include <autoware_vehicle_msgs/msg/engage.hpp>
+#include <autoware_auto_planning_msgs/msg/route.hpp>
+#include <autoware_auto_planning_msgs/msg/trajectory.hpp>
+#include <autoware_auto_system_msgs/msg/autoware_state.hpp>
+#include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
+#include <autoware_auto_vehicle_msgs/msg/engage.hpp>
+#include <autoware_auto_vehicle_msgs/msg/vehicle_state_report.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
-#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 
 #include <deque>
 #include <string>
@@ -45,14 +45,14 @@ struct StateInput
   geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose;
   geometry_msgs::msg::Pose::ConstSharedPtr goal_pose;
 
-  autoware_vehicle_msgs::msg::Engage::ConstSharedPtr autoware_engage;
-  autoware_vehicle_msgs::msg::ControlMode::ConstSharedPtr vehicle_control_mode;
-  autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr hazard_status;
+  autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr autoware_engage;
+  autoware_auto_vehicle_msgs::msg::VehicleStateReport::ConstSharedPtr vehicle_state_report;
+  autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr hazard_status;
   bool is_finalizing = false;
   bool is_route_reset_required = false;
-  autoware_planning_msgs::msg::Route::ConstSharedPtr route;
-  geometry_msgs::msg::TwistStamped::ConstSharedPtr twist;
-  std::deque<geometry_msgs::msg::TwistStamped::ConstSharedPtr> twist_buffer;
+  autoware_auto_planning_msgs::msg::Route::ConstSharedPtr route;
+  nav_msgs::msg::Odometry::ConstSharedPtr odometry;
+  std::deque<nav_msgs::msg::Odometry::ConstSharedPtr> odometry_buffer;
 };
 
 struct StateParam
@@ -93,7 +93,7 @@ private:
   mutable std::vector<std::string> msgs_;
   mutable Times times_;
   mutable Flags flags_;
-  mutable autoware_planning_msgs::msg::Route::ConstSharedPtr executing_route_ = nullptr;
+  mutable autoware_auto_planning_msgs::msg::Route::ConstSharedPtr executing_route_ = nullptr;
 
   AutowareState judgeAutowareState() const;
 

--- a/system/autoware_state_monitor/include/autoware_state_monitor/state_machine.hpp
+++ b/system/autoware_state_monitor/include/autoware_state_monitor/state_machine.hpp
@@ -89,7 +89,6 @@ private:
   StateInput state_input_;
   const StateParam state_param_;
 
-  mutable AutowareState state_before_emergency_ = AutowareState::InitializingVehicle;
   mutable std::vector<std::string> msgs_;
   mutable Times times_;
   mutable Flags flags_;
@@ -104,7 +103,6 @@ private:
   bool isPlanningCompleted() const;
   bool isEngaged() const;
   bool isOverridden() const;
-  bool isEmergency() const;
   bool hasArrivedGoal() const;
   bool isFinalizing() const;
   bool isRouteResetRequired() const;

--- a/system/autoware_state_monitor/include/autoware_state_monitor/state_machine.hpp
+++ b/system/autoware_state_monitor/include/autoware_state_monitor/state_machine.hpp
@@ -24,7 +24,6 @@
 #include <autoware_auto_planning_msgs/msg/route.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
-#include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
 #include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <autoware_auto_vehicle_msgs/msg/vehicle_state_report.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -47,7 +46,6 @@ struct StateInput
 
   autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr autoware_engage;
   autoware_auto_vehicle_msgs::msg::VehicleStateReport::ConstSharedPtr vehicle_state_report;
-  autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr hazard_status;
   bool is_finalizing = false;
   bool is_route_reset_required = false;
   autoware_auto_planning_msgs::msg::Route::ConstSharedPtr route;

--- a/system/autoware_state_monitor/launch/autoware_state_monitor.launch.xml
+++ b/system/autoware_state_monitor/launch/autoware_state_monitor.launch.xml
@@ -1,10 +1,10 @@
 <launch>
   <!-- Input -->
   <arg name="input_autoware_engage" default="/api/autoware/get/engage" />
-  <arg name="input_vehicle_control_mode" default="/vehicle/status/control_mode" />
+  <arg name="input_vehicle_state_report" default="/vehicle/state_report" />
   <arg name="input_hazard_status" default="/system/emergency/hazard_status" />
   <arg name="input_route" default="/planning/mission_planning/route" />
-  <arg name="input_twist" default="/localization/twist" />
+  <arg name="input_odometry" default="/localization/ekf_odom" />
 
   <!-- Output -->
   <arg name="output_autoware_state" default="/autoware/state" />
@@ -27,10 +27,10 @@
 
   <node pkg="autoware_state_monitor" exec="autoware_state_monitor" name="autoware_state_monitor" output="screen">
     <remap from="input/autoware_engage" to="$(var input_autoware_engage)"/>
-    <remap from="input/vehicle_control_mode" to="$(var input_vehicle_control_mode)"/>
+    <remap from="input/vehicle_state_report" to="$(var input_vehicle_state_report)"/>
     <remap from="input/hazard_status" to="$(var input_hazard_status)"/>
     <remap from="input/route" to="$(var input_route)"/>
-    <remap from="input/twist" to="$(var input_twist)"/>
+    <remap from="input/odometry" to="$(var input_odometry)"/>
 
     <remap from="output/autoware_state" to="$(var output_autoware_state)"/>
     <remap from="output/autoware_engage" to="$(var output_autoware_engage)"/>

--- a/system/autoware_state_monitor/launch/autoware_state_monitor.launch.xml
+++ b/system/autoware_state_monitor/launch/autoware_state_monitor.launch.xml
@@ -2,7 +2,6 @@
   <!-- Input -->
   <arg name="input_autoware_engage" default="/api/autoware/get/engage" />
   <arg name="input_vehicle_state_report" default="/vehicle/state_report" />
-  <arg name="input_hazard_status" default="/system/emergency/hazard_status" />
   <arg name="input_route" default="/planning/mission_planning/route" />
   <arg name="input_odometry" default="/localization/ekf_odom" />
 
@@ -28,7 +27,6 @@
   <node pkg="autoware_state_monitor" exec="autoware_state_monitor" name="autoware_state_monitor" output="screen">
     <remap from="input/autoware_engage" to="$(var input_autoware_engage)"/>
     <remap from="input/vehicle_state_report" to="$(var input_vehicle_state_report)"/>
-    <remap from="input/hazard_status" to="$(var input_hazard_status)"/>
     <remap from="input/route" to="$(var input_route)"/>
     <remap from="input/odometry" to="$(var input_odometry)"/>
 

--- a/system/autoware_state_monitor/package.xml
+++ b/system/autoware_state_monitor/package.xml
@@ -9,13 +9,14 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>autoware_control_msgs</depend>
-  <depend>autoware_planning_msgs</depend>
-  <depend>autoware_system_msgs</depend>
-  <depend>autoware_vehicle_msgs</depend>
+  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_auto_system_msgs</depend>
+  <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>

--- a/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
+++ b/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
@@ -73,6 +73,8 @@ geometry_msgs::msg::PoseStamped::SharedPtr getCurrentPose(const tf2_ros::Buffer 
   return p;
 }
 
+// unused
+/*
 std::string getStateMessage(const AutowareState & state)
 {
   if (state == AutowareState::InitializingVehicle) {
@@ -110,35 +112,37 @@ std::string getStateMessage(const AutowareState & state)
 
   throw std::runtime_error("invalid state");
 }
+*/
 
 }  // namespace
 
 void AutowareStateMonitorNode::onAutowareEngage(
-  const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
+  const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
 {
   state_input_.autoware_engage = msg;
 }
 
-void AutowareStateMonitorNode::onVehicleControlMode(
-  const autoware_vehicle_msgs::msg::ControlMode::ConstSharedPtr msg)
+void AutowareStateMonitorNode::onVehicleVehicleStateReport(
+  const autoware_auto_vehicle_msgs::msg::VehicleStateReport::ConstSharedPtr msg)
 {
-  state_input_.vehicle_control_mode = msg;
+  state_input_.vehicle_state_report = msg;
 }
 
 void AutowareStateMonitorNode::onHazardStatus(
-  const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg)
+  const autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg)
 {
   state_input_.hazard_status = msg;
 }
 
-void AutowareStateMonitorNode::onRoute(const autoware_planning_msgs::msg::Route::ConstSharedPtr msg)
+void AutowareStateMonitorNode::onRoute(
+  const autoware_auto_planning_msgs::msg::Route::ConstSharedPtr msg)
 {
   state_input_.route = msg;
 
   // Get goal pose
   {
     geometry_msgs::msg::Pose::SharedPtr p = std::make_shared<geometry_msgs::msg::Pose>();
-    *p = msg->goal_pose;
+    *p = msg->goal_point.pose;
     state_input_.goal_pose = geometry_msgs::msg::Pose::ConstSharedPtr(p);
   }
 
@@ -148,22 +152,22 @@ void AutowareStateMonitorNode::onRoute(const autoware_planning_msgs::msg::Route:
   }
 }
 
-void AutowareStateMonitorNode::onTwist(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+void AutowareStateMonitorNode::onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg)
 {
-  state_input_.twist = msg;
+  state_input_.odometry = msg;
 
-  state_input_.twist_buffer.push_back(msg);
+  state_input_.odometry_buffer.push_back(msg);
 
   // Delete old data in buffer
   while (true) {
     const auto time_diff = rclcpp::Time(msg->header.stamp) -
-                           rclcpp::Time(state_input_.twist_buffer.front()->header.stamp);
+                           rclcpp::Time(state_input_.odometry_buffer.front()->header.stamp);
 
     if (time_diff.seconds() < state_param_.th_stopped_time_sec) {
       break;
     }
 
-    state_input_.twist_buffer.pop_front();
+    state_input_.odometry_buffer.pop_front();
   }
 }
 
@@ -257,8 +261,8 @@ void AutowareStateMonitorNode::onTimer()
 
   if (autoware_state != prev_autoware_state) {
     RCLCPP_INFO(
-      this->get_logger(), "state changed: %s -> %s", toString(prev_autoware_state).c_str(),
-      toString(autoware_state).c_str());
+      this->get_logger(), "state changed: %i -> %i", toMsg(prev_autoware_state),
+      toMsg(autoware_state));
   }
 
   // Disengage on event
@@ -269,19 +273,8 @@ void AutowareStateMonitorNode::onTimer()
 
   // Publish state message
   {
-    autoware_system_msgs::msg::AutowareState autoware_state_msg;
-    autoware_state_msg.state = toString(autoware_state);
-
-    // Add messages line by line
-    std::ostringstream oss;
-
-    oss << getStateMessage(autoware_state) << std::endl;
-
-    for (const auto & msg : state_machine_->getMessages()) {
-      oss << msg << std::endl;
-    }
-
-    autoware_state_msg.msg = oss.str();
+    autoware_auto_system_msgs::msg::AutowareState autoware_state_msg;
+    autoware_state_msg.state = toMsg(autoware_state);
 
     pub_autoware_state_->publish(autoware_state_msg);
   }
@@ -430,7 +423,7 @@ bool AutowareStateMonitorNode::isEngaged()
 
 void AutowareStateMonitorNode::setDisengage()
 {
-  autoware_vehicle_msgs::msg::Engage msg;
+  autoware_auto_vehicle_msgs::msg::Engage msg;
   msg.stamp = this->now();
   msg.engage = false;
   pub_autoware_engage_->publish(msg);
@@ -477,20 +470,24 @@ AutowareStateMonitorNode::AutowareStateMonitorNode()
   }
 
   // Subscriber
-  sub_autoware_engage_ = this->create_subscription<autoware_vehicle_msgs::msg::Engage>(
+  sub_autoware_engage_ = this->create_subscription<autoware_auto_vehicle_msgs::msg::Engage>(
     "input/autoware_engage", 1, std::bind(&AutowareStateMonitorNode::onAutowareEngage, this, _1),
     subscriber_option);
-  sub_vehicle_control_mode_ = this->create_subscription<autoware_vehicle_msgs::msg::ControlMode>(
-    "input/vehicle_control_mode", 1,
-    std::bind(&AutowareStateMonitorNode::onVehicleControlMode, this, _1), subscriber_option);
-  sub_hazard_status = this->create_subscription<autoware_system_msgs::msg::HazardStatusStamped>(
-    "input/hazard_status", 1, std::bind(&AutowareStateMonitorNode::onHazardStatus, this, _1),
-    subscriber_option);
-  sub_route_ = this->create_subscription<autoware_planning_msgs::msg::Route>(
+  sub_vehicle_state_report_ =
+    this->create_subscription<autoware_auto_vehicle_msgs::msg::VehicleStateReport>(
+      "input/vehicle_state_report", 1,
+      std::bind(&AutowareStateMonitorNode::onVehicleVehicleStateReport, this, _1),
+      subscriber_option);
+  sub_hazard_status =
+    this->create_subscription<autoware_auto_system_msgs::msg::HazardStatusStamped>(
+      "input/hazard_status", 1, std::bind(&AutowareStateMonitorNode::onHazardStatus, this, _1),
+      subscriber_option);
+  sub_route_ = this->create_subscription<autoware_auto_planning_msgs::msg::Route>(
     "input/route", rclcpp::QoS{1}.transient_local(),
     std::bind(&AutowareStateMonitorNode::onRoute, this, _1), subscriber_option);
-  sub_twist_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
-    "input/twist", 100, std::bind(&AutowareStateMonitorNode::onTwist, this, _1), subscriber_option);
+  sub_odom_ = this->create_subscription<nav_msgs::msg::Odometry>(
+    "input/odometry", 100, std::bind(&AutowareStateMonitorNode::onOdometry, this, _1),
+    subscriber_option);
 
   // Service
   srv_shutdown_ = this->create_service<std_srvs::srv::Trigger>(
@@ -502,10 +499,10 @@ AutowareStateMonitorNode::AutowareStateMonitorNode()
     rmw_qos_profile_services_default, callback_group_services_);
 
   // Publisher
-  pub_autoware_state_ =
-    this->create_publisher<autoware_system_msgs::msg::AutowareState>("output/autoware_state", 1);
+  pub_autoware_state_ = this->create_publisher<autoware_auto_system_msgs::msg::AutowareState>(
+    "output/autoware_state", 1);
   pub_autoware_engage_ =
-    this->create_publisher<autoware_vehicle_msgs::msg::Engage>("output/autoware_engage", 1);
+    this->create_publisher<autoware_auto_vehicle_msgs::msg::Engage>("output/autoware_engage", 1);
 
   // Diagnostic Updater
   setupDiagnosticUpdater();

--- a/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
+++ b/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
@@ -73,47 +73,6 @@ geometry_msgs::msg::PoseStamped::SharedPtr getCurrentPose(const tf2_ros::Buffer 
   return p;
 }
 
-// unused
-/*
-std::string getStateMessage(const AutowareState & state)
-{
-  if (state == AutowareState::InitializingVehicle) {
-    return "Please wait for a while. If the current pose is not estimated automatically, please "
-           "set it manually.";
-  }
-
-  if (state == AutowareState::WaitingForRoute) {
-    return "Please send a route.";
-  }
-
-  if (state == AutowareState::Planning) {
-    return "Please wait for a while.";
-  }
-
-  if (state == AutowareState::WaitingForEngage) {
-    return "Please set engage.";
-  }
-
-  if (state == AutowareState::Driving) {
-    return "Under autonomous driving. Have fun!";
-  }
-
-  if (state == AutowareState::ArrivedGoal) {
-    return "Autonomous driving has completed. Thank you!";
-  }
-
-  if (state == AutowareState::Emergency) {
-    return "Emergency! Please recover the system.";
-  }
-
-  if (state == AutowareState::Finalizing) {
-    return "Finalizing Autoware...";
-  }
-
-  throw std::runtime_error("invalid state");
-}
-*/
-
 }  // namespace
 
 void AutowareStateMonitorNode::onAutowareEngage(

--- a/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
+++ b/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
@@ -87,12 +87,6 @@ void AutowareStateMonitorNode::onVehicleVehicleStateReport(
   state_input_.vehicle_state_report = msg;
 }
 
-void AutowareStateMonitorNode::onHazardStatus(
-  const autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg)
-{
-  state_input_.hazard_status = msg;
-}
-
 void AutowareStateMonitorNode::onRoute(
   const autoware_auto_planning_msgs::msg::Route::ConstSharedPtr msg)
 {
@@ -436,10 +430,6 @@ AutowareStateMonitorNode::AutowareStateMonitorNode()
     this->create_subscription<autoware_auto_vehicle_msgs::msg::VehicleStateReport>(
       "input/vehicle_state_report", 1,
       std::bind(&AutowareStateMonitorNode::onVehicleVehicleStateReport, this, _1),
-      subscriber_option);
-  sub_hazard_status =
-    this->create_subscription<autoware_auto_system_msgs::msg::HazardStatusStamped>(
-      "input/hazard_status", 1, std::bind(&AutowareStateMonitorNode::onHazardStatus, this, _1),
       subscriber_option);
   sub_route_ = this->create_subscription<autoware_auto_planning_msgs::msg::Route>(
     "input/route", rclcpp::QoS{1}.transient_local(),

--- a/system/autoware_state_monitor/src/autoware_state_monitor_node/state_machine.cpp
+++ b/system/autoware_state_monitor/src/autoware_state_monitor_node/state_machine.cpp
@@ -40,11 +40,11 @@ bool isNearGoal(
 }
 
 bool isStopped(
-  const std::deque<geometry_msgs::msg::TwistStamped::ConstSharedPtr> & twist_buffer,
+  const std::deque<nav_msgs::msg::Odometry::ConstSharedPtr> & odometry_buffer,
   const double th_stopped_velocity_mps)
 {
-  for (const auto & twist : twist_buffer) {
-    if (std::abs(twist->twist.linear.x) > th_stopped_velocity_mps) {
+  for (const auto & odometry : odometry_buffer) {
+    if (std::abs(odometry->twist.twist.linear.x) > th_stopped_velocity_mps) {
       return false;
     }
   }
@@ -158,11 +158,13 @@ bool StateMachine::isEngaged() const
     return false;
   }
 
-  if (!state_input_.vehicle_control_mode) {
+  if (!state_input_.vehicle_state_report) {
     return false;
   }
 
-  if (state_input_.vehicle_control_mode->data == autoware_vehicle_msgs::msg::ControlMode::MANUAL) {
+  if (
+    state_input_.vehicle_state_report->mode ==
+    autoware_auto_vehicle_msgs::msg::VehicleStateReport::MODE_MANUAL) {
     return false;
   }
 
@@ -185,7 +187,7 @@ bool StateMachine::hasArrivedGoal() const
   const auto is_near_goal = isNearGoal(
     state_input_.current_pose->pose, *state_input_.goal_pose, state_param_.th_arrived_distance_m);
   const auto is_stopped =
-    isStopped(state_input_.twist_buffer, state_param_.th_stopped_velocity_mps);
+    isStopped(state_input_.odometry_buffer, state_param_.th_stopped_velocity_mps);
 
   if (is_near_goal && is_stopped) {
     return true;

--- a/system/autoware_state_monitor/src/autoware_state_monitor_node/state_machine.cpp
+++ b/system/autoware_state_monitor/src/autoware_state_monitor_node/state_machine.cpp
@@ -173,15 +173,6 @@ bool StateMachine::isEngaged() const
 
 bool StateMachine::isOverridden() const { return !isEngaged(); }
 
-bool StateMachine::isEmergency() const
-{
-  if (!state_input_.hazard_status) {
-    return false;
-  }
-
-  return state_input_.hazard_status->status.emergency_holding;
-}
-
 bool StateMachine::hasArrivedGoal() const
 {
   const auto is_near_goal = isNearGoal(
@@ -212,11 +203,6 @@ AutowareState StateMachine::judgeAutowareState() const
 {
   if (isFinalizing()) {
     return AutowareState::Finalizing;
-  }
-
-  if (autoware_state_ != AutowareState::Emergency && isEmergency()) {
-    state_before_emergency_ = autoware_state_;
-    return AutowareState::Emergency;
   }
 
   switch (autoware_state_) {
@@ -318,14 +304,6 @@ AutowareState StateMachine::judgeAutowareState() const
       const auto time_from_arrived_goal = state_input_.current_time - times_.arrived_goal;
       if (time_from_arrived_goal.seconds() > wait_time_after_arrived_goal) {
         return AutowareState::WaitingForRoute;
-      }
-
-      break;
-    }
-
-    case (AutowareState::Emergency): {
-      if (!isEmergency()) {
-        return state_before_emergency_;
       }
 
       break;


### PR DESCRIPTION
## Description

support .auto msg
autoware_planning_msgs/msg/route -> autoware_auto_planning_msgs/msg/route

autoware_planning_msgs/msg/trajectory -> autoware_auto_planning_msgs/msg/trajectory

autoware_system_msgs/msg/autoware_state -> autoware_auto_system_msgs/msg/autoware_state

autoware_system_msgs/msg/engage -> autoware_auto_system_msgs/msg/engage

autoware_system_msgs/msg/hazard_status_stamped -> autoware_auto_system_msgs/msg/hazard_status_stamped

autoware_vehicle_msgs/msg/control_mode -> autoware_auto_vehicle_msgs/msg/vehicle_state_report

geometry_msgs/msg/twist_stamped -> nav_msgs/msg/odomtery

- add readme (from scratch)

### Remaining Issues
~- Handling of string message in original AutowareState.msg~
~- Handling of Emergency state in original AutowareState.msg~

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
