### PR TITLE
.auto porting as

### DIFF
--- a/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
+++ b/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
@@ -30,7 +30,6 @@
 #include <autoware_auto_vehicle_msgs/msg/turn_indicators_report.hpp>
 #include <autoware_vehicle_msgs/msg/actuation_command_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/actuation_status_stamped.hpp>
-#include <autoware_vehicle_msgs/msg/control_mode.hpp>
 #include <autoware_vehicle_msgs/msg/vehicle_emergency_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <pacmod_msgs/msg/global_rpt.hpp>

--- a/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
+++ b/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
@@ -31,7 +31,7 @@
 #include <autoware_vehicle_msgs/msg/actuation_command_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/actuation_status_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode.hpp>
-#include <autoware_vehicle_msgs/msg/vehicle_command.hpp>
+#include <autoware_vehicle_msgs/msg/vehicle_emergency_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <pacmod_msgs/msg/global_rpt.hpp>
 #include <pacmod_msgs/msg/steer_system_cmd.hpp>
@@ -76,7 +76,8 @@ private:
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::Engage>::SharedPtr engage_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::ActuationCommandStamped>::SharedPtr
     actuation_cmd_sub_;
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::VehicleCommand>::SharedPtr vehicle_cmd_sub_;
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::VehicleEmergencyStamped>::SharedPtr
+    emergency_sub_;
 
   // From Pacmod
   std::unique_ptr<message_filters::Subscriber<pacmod_msgs::msg::SystemRptFloat>>
@@ -178,7 +179,10 @@ private:
     const autoware_vehicle_msgs::msg::ActuationCommandStamped::ConstSharedPtr msg);
   void callbackControlCmd(
     const autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr msg);
-  void callbackVehicleCmd(const autoware_vehicle_msgs::msg::VehicleCommand::ConstSharedPtr msg);
+
+  void callbackEmergencyCmd(
+    const autoware_vehicle_msgs::msg::VehicleEmergencyStamped::ConstSharedPtr msg);
+
   void callbackGearCmd(const autoware_auto_vehicle_msgs::msg::GearCommand::ConstSharedPtr msg);
   void callbackTurnIndicatorsCommand(
     const autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand::ConstSharedPtr msg);

--- a/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
+++ b/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
@@ -20,10 +20,10 @@
 
 #include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/engage.hpp>
+#include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_vehicle_msgs/msg/actuation_command_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/actuation_status_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode.hpp>
-#include <autoware_vehicle_msgs/msg/shift_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/steering.hpp>
 #include <autoware_vehicle_msgs/msg/turn_signal.hpp>
 #include <autoware_vehicle_msgs/msg/vehicle_command.hpp>
@@ -62,7 +62,7 @@ private:
   // From Autoware
   rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
     control_cmd_sub_;
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::ShiftStamped>::SharedPtr shift_cmd_sub_;
+  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr gear_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr turn_signal_cmd_sub_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::Engage>::SharedPtr engage_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::ActuationCommandStamped>::SharedPtr
@@ -95,7 +95,7 @@ private:
   rclcpp::Publisher<autoware_vehicle_msgs::msg::ControlMode>::SharedPtr control_mode_pub_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr vehicle_twist_pub_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::Steering>::SharedPtr steering_status_pub_;
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::ShiftStamped>::SharedPtr shift_status_pub_;
+  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr gear_cmd_status_pub_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr turn_signal_status_pub_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::ActuationStatusStamped>::SharedPtr
     actuation_status_pub_;
@@ -141,14 +141,14 @@ private:
   autoware_vehicle_msgs::msg::ActuationCommandStamped::ConstSharedPtr actuation_cmd_ptr_;
   autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr control_cmd_ptr_;
   autoware_vehicle_msgs::msg::TurnSignal::ConstSharedPtr turn_signal_cmd_ptr_;
-  autoware_vehicle_msgs::msg::ShiftStamped::ConstSharedPtr shift_cmd_ptr_;
+  autoware_auto_vehicle_msgs::msg::GearCommand::ConstSharedPtr gear_cmd_ptr_;
 
   pacmod_msgs::msg::SystemRptFloat::ConstSharedPtr steer_wheel_rpt_ptr_;  // [rad]
   pacmod_msgs::msg::WheelSpeedRpt::ConstSharedPtr wheel_speed_rpt_ptr_;   // [m/s]
   pacmod_msgs::msg::SystemRptFloat::ConstSharedPtr accel_rpt_ptr_;
-  pacmod_msgs::msg::SystemRptFloat::ConstSharedPtr brake_rpt_ptr_;  // [m/s]
-  pacmod_msgs::msg::SystemRptInt::ConstSharedPtr shift_rpt_ptr_;    // [m/s]
-  pacmod_msgs::msg::GlobalRpt::ConstSharedPtr global_rpt_ptr_;      // [m/s]
+  pacmod_msgs::msg::SystemRptFloat::ConstSharedPtr brake_rpt_ptr_;   // [m/s]
+  pacmod_msgs::msg::SystemRptInt::ConstSharedPtr gear_cmd_rpt_ptr_;  // [m/s]
+  pacmod_msgs::msg::GlobalRpt::ConstSharedPtr global_rpt_ptr_;       // [m/s]
   pacmod_msgs::msg::SystemRptInt::ConstSharedPtr turn_rpt_ptr_;
   pacmod_msgs::msg::SteerSystemCmd prev_steer_cmd_;
 
@@ -164,7 +164,7 @@ private:
   void callbackControlCmd(
     const autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr msg);
   void callbackVehicleCmd(const autoware_vehicle_msgs::msg::VehicleCommand::ConstSharedPtr msg);
-  void callbackShiftCmd(const autoware_vehicle_msgs::msg::ShiftStamped::ConstSharedPtr msg);
+  void callbackGearCmd(const autoware_auto_vehicle_msgs::msg::GearCommand::ConstSharedPtr msg);
   void callbackTurnSignalCmd(const autoware_vehicle_msgs::msg::TurnSignal::ConstSharedPtr msg);
   void callbackEngage(const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
   void callbackPacmodRpt(
@@ -172,7 +172,7 @@ private:
     const pacmod_msgs::msg::WheelSpeedRpt::ConstSharedPtr wheel_speed_rpt,
     const pacmod_msgs::msg::SystemRptFloat::ConstSharedPtr accel_rpt,
     const pacmod_msgs::msg::SystemRptFloat::ConstSharedPtr brake_rpt,
-    const pacmod_msgs::msg::SystemRptInt::ConstSharedPtr shift_rpt,
+    const pacmod_msgs::msg::SystemRptInt::ConstSharedPtr gear_cmd_rpt,
     const pacmod_msgs::msg::SystemRptInt::ConstSharedPtr turn_rpt,
     const pacmod_msgs::msg::GlobalRpt::ConstSharedPtr global_rpt);
 
@@ -183,7 +183,7 @@ private:
     const pacmod_msgs::msg::SystemRptInt & shift_rpt);
   double calculateVariableGearRatio(const double vel, const double steer_wheel);
   double calcSteerWheelRateCmd(const double gear_ratio);
-  uint16_t toPacmodShiftCmd(const autoware_vehicle_msgs::msg::Shift & shift);
+  uint16_t toPacmodShiftCmd(const autoware_auto_vehicle_msgs::msg::GearCommand & gear_cmd);
   uint16_t toPacmodTurnCmd(const autoware_vehicle_msgs::msg::TurnSignal & turn);
   uint16_t toPacmodTurnCmdWithHazardRecover(const autoware_vehicle_msgs::msg::TurnSignal & turn);
   int32_t toAutowareShiftCmd(const pacmod_msgs::msg::SystemRptInt & shift);

--- a/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
+++ b/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
@@ -41,8 +41,6 @@
 #include <pacmod_msgs/msg/system_rpt_int.hpp>
 #include <pacmod_msgs/msg/wheel_speed_rpt.hpp>
 
-#include <boost/optional.hpp>
-
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>
@@ -51,6 +49,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <string>
 
 class PacmodInterface : public rclcpp::Node
@@ -210,7 +209,7 @@ private:
     const autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand & turn,
     const autoware_auto_vehicle_msgs::msg::HazardLightsCommand & hazard);
 
-  boost::optional<int32_t> toAutowareShiftReport(const pacmod_msgs::msg::SystemRptInt & shift);
+  std::optional<int32_t> toAutowareShiftReport(const pacmod_msgs::msg::SystemRptInt & shift);
   int32_t toAutowareTurnIndicatorsReport(const pacmod_msgs::msg::SystemRptInt & turn);
   int32_t toAutowareHazardLightsReport(const pacmod_msgs::msg::SystemRptInt & turn);
   double steerWheelRateLimiter(

--- a/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
+++ b/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
@@ -18,7 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
-#include <autoware_control_msgs/msg/control_command_stamped.hpp>
+#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
 #include <autoware_vehicle_msgs/msg/actuation_command_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/actuation_status_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode.hpp>
@@ -60,7 +60,7 @@ private:
 
   /* subscribers */
   // From Autoware
-  rclcpp::Subscription<autoware_control_msgs::msg::ControlCommandStamped>::SharedPtr
+  rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
     control_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::ShiftStamped>::SharedPtr shift_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr turn_signal_cmd_sub_;
@@ -139,7 +139,7 @@ private:
 
   /* input values */
   autoware_vehicle_msgs::msg::ActuationCommandStamped::ConstSharedPtr actuation_cmd_ptr_;
-  autoware_control_msgs::msg::ControlCommandStamped::ConstSharedPtr control_cmd_ptr_;
+  autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr control_cmd_ptr_;
   autoware_vehicle_msgs::msg::TurnSignal::ConstSharedPtr turn_signal_cmd_ptr_;
   autoware_vehicle_msgs::msg::ShiftStamped::ConstSharedPtr shift_cmd_ptr_;
 
@@ -162,7 +162,7 @@ private:
   void callbackActuationCmd(
     const autoware_vehicle_msgs::msg::ActuationCommandStamped::ConstSharedPtr msg);
   void callbackControlCmd(
-    const autoware_control_msgs::msg::ControlCommandStamped::ConstSharedPtr msg);
+    const autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr msg);
   void callbackVehicleCmd(const autoware_vehicle_msgs::msg::VehicleCommand::ConstSharedPtr msg);
   void callbackShiftCmd(const autoware_vehicle_msgs::msg::ShiftStamped::ConstSharedPtr msg);
   void callbackTurnSignalCmd(const autoware_vehicle_msgs::msg::TurnSignal::ConstSharedPtr msg);

--- a/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
+++ b/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
@@ -19,17 +19,18 @@
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
 #include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
 #include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/hazard_lights_report.hpp>
+#include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/turn_indicators_report.hpp>
 #include <autoware_vehicle_msgs/msg/actuation_command_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/actuation_status_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode.hpp>
-#include <autoware_vehicle_msgs/msg/steering.hpp>
 #include <autoware_vehicle_msgs/msg/vehicle_command.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <pacmod_msgs/msg/global_rpt.hpp>
@@ -101,9 +102,11 @@ private:
     raw_steer_cmd_pub_;  // only for debug
 
   // To Autoware
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::ControlMode>::SharedPtr control_mode_pub_;
+  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::ControlModeReport>::SharedPtr
+    control_mode_pub_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr vehicle_twist_pub_;
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::Steering>::SharedPtr steering_status_pub_;
+  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::SteeringReport>::SharedPtr
+    steering_status_pub_;
   rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearReport>::SharedPtr gear_status_pub_;
   rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::TurnIndicatorsReport>::SharedPtr
     turn_indicators_status_pub_;

--- a/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
+++ b/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
@@ -19,10 +19,10 @@
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
 #include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <autoware_vehicle_msgs/msg/actuation_command_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/actuation_status_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode.hpp>
-#include <autoware_vehicle_msgs/msg/engage.hpp>
 #include <autoware_vehicle_msgs/msg/shift_stamped.hpp>
 #include <autoware_vehicle_msgs/msg/steering.hpp>
 #include <autoware_vehicle_msgs/msg/turn_signal.hpp>
@@ -64,7 +64,7 @@ private:
     control_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::ShiftStamped>::SharedPtr shift_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::TurnSignal>::SharedPtr turn_signal_cmd_sub_;
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::Engage>::SharedPtr engage_cmd_sub_;
+  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::Engage>::SharedPtr engage_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::ActuationCommandStamped>::SharedPtr
     actuation_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::VehicleCommand>::SharedPtr vehicle_cmd_sub_;
@@ -166,7 +166,7 @@ private:
   void callbackVehicleCmd(const autoware_vehicle_msgs::msg::VehicleCommand::ConstSharedPtr msg);
   void callbackShiftCmd(const autoware_vehicle_msgs::msg::ShiftStamped::ConstSharedPtr msg);
   void callbackTurnSignalCmd(const autoware_vehicle_msgs::msg::TurnSignal::ConstSharedPtr msg);
-  void callbackEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
+  void callbackEngage(const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
   void callbackPacmodRpt(
     const pacmod_msgs::msg::SystemRptFloat::ConstSharedPtr steer_wheel_rpt,
     const pacmod_msgs::msg::WheelSpeedRpt::ConstSharedPtr wheel_speed_rpt,

--- a/vehicle/as/package.xml
+++ b/vehicle/as/package.xml
@@ -13,7 +13,7 @@
 
   <depend>automotive_navigation_msgs</depend>
   <depend>automotive_platform_msgs</depend>
-  <depend>autoware_control_msgs</depend>
+  <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_debug_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>can_msgs</depend>

--- a/vehicle/as/package.xml
+++ b/vehicle/as/package.xml
@@ -14,6 +14,7 @@
   <depend>automotive_navigation_msgs</depend>
   <depend>automotive_platform_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_debug_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>can_msgs</depend>

--- a/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
@@ -72,7 +72,7 @@ PacmodInterface::PacmodInterface()
   turn_signal_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::TurnSignal>(
     "/control/turn_signal_cmd", rclcpp::QoS{1},
     std::bind(&PacmodInterface::callbackTurnSignalCmd, this, _1));
-  engage_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::Engage>(
+  engage_cmd_sub_ = create_subscription<autoware_auto_vehicle_msgs::msg::Engage>(
     "/vehicle/engage", rclcpp::QoS{1}, std::bind(&PacmodInterface::callbackEngage, this, _1));
   actuation_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::ActuationCommandStamped>(
     "/vehicle/actuation_cmd", 1, std::bind(&PacmodInterface::callbackActuationCmd, this, _1));
@@ -179,7 +179,8 @@ void PacmodInterface::callbackTurnSignalCmd(
   turn_signal_cmd_ptr_ = msg;
 }
 
-void PacmodInterface::callbackEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
+void PacmodInterface::callbackEngage(
+  const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
 {
   engage_cmd_ = msg->engage;
   is_clear_override_needed_ = true;

--- a/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
@@ -591,14 +591,15 @@ uint16_t PacmodInterface::toPacmodTurnCmd(
   using autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand;
   using pacmod_msgs::msg::SystemCmdInt;
 
+  // NOTE: hazard lights command has a highest priority here.
+  if (hazard.command == HazardLightsCommand::ENABLE) {
+    return SystemCmdInt::TURN_HAZARDS;
+  }
   if (turn.command == TurnIndicatorsCommand::ENABLE_LEFT) {
     return SystemCmdInt::TURN_LEFT;
   }
   if (turn.command == TurnIndicatorsCommand::ENABLE_RIGHT) {
     return SystemCmdInt::TURN_RIGHT;
-  }
-  if (hazard.command == HazardLightsCommand::ENABLE) {
-    return SystemCmdInt::TURN_HAZARDS;
   }
   return SystemCmdInt::TURN_NONE;
 }

--- a/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
@@ -476,7 +476,7 @@ void PacmodInterface::publishCommands()
     shift_cmd_pub_->publish(shift_cmd);
   }
 
-  if (turn_indicators_cmd_ptr_) {
+  if (turn_indicators_cmd_ptr_ && hazard_lights_cmd_ptr_) {
     /* publish shift cmd */
     pacmod_msgs::msg::SystemCmdInt turn_cmd;
     turn_cmd.header.frame_id = base_frame_id_;
@@ -634,7 +634,6 @@ uint16_t PacmodInterface::toPacmodTurnCmdWithHazardRecover(
   }
 }
 
-// TODO(murooka) disable
 int32_t PacmodInterface::toAutowareTurnIndicatorsReport(const pacmod_msgs::msg::SystemRptInt & turn)
 {
   using autoware_auto_vehicle_msgs::msg::TurnIndicatorsReport;
@@ -650,7 +649,6 @@ int32_t PacmodInterface::toAutowareTurnIndicatorsReport(const pacmod_msgs::msg::
   return TurnIndicatorsReport::DISABLE;
 }
 
-// TODO(murooka) disable
 int32_t PacmodInterface::toAutowareHazardLightsReport(const pacmod_msgs::msg::SystemRptInt & hazard)
 {
   using autoware_auto_vehicle_msgs::msg::HazardLightsReport;

--- a/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
@@ -280,7 +280,7 @@ void PacmodInterface::callbackPacmodRpt(
     gear_report_msg.stamp = header.stamp;
     const auto opt_gear_report = toAutowareShiftReport(*gear_cmd_rpt_ptr_);
     if (opt_gear_report) {
-      gear_report_msg.report = opt_gear_report.get();
+      gear_report_msg.report = *opt_gear_report;
       gear_status_pub_->publish(gear_report_msg);
     }
   }
@@ -562,7 +562,7 @@ uint16_t PacmodInterface::toPacmodShiftCmd(
   return SystemCmdInt::SHIFT_NONE;
 }
 
-boost::optional<int32_t> PacmodInterface::toAutowareShiftReport(
+std::optional<int32_t> PacmodInterface::toAutowareShiftReport(
   const pacmod_msgs::msg::SystemRptInt & shift)
 {
   using autoware_auto_vehicle_msgs::msg::GearReport;
@@ -580,7 +580,7 @@ boost::optional<int32_t> PacmodInterface::toAutowareShiftReport(
   if (shift.output == SystemRptInt::SHIFT_LOW) {
     return GearReport::LOW;
   }
-  return boost::none;
+  return {};
 }
 
 uint16_t PacmodInterface::toPacmodTurnCmd(

--- a/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
@@ -81,8 +81,8 @@ PacmodInterface::PacmodInterface()
     "/vehicle/engage", rclcpp::QoS{1}, std::bind(&PacmodInterface::callbackEngage, this, _1));
   actuation_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::ActuationCommandStamped>(
     "/vehicle/actuation_cmd", 1, std::bind(&PacmodInterface::callbackActuationCmd, this, _1));
-  vehicle_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::VehicleCommand>(
-    "/control/vehicle_cmd", 1, std::bind(&PacmodInterface::callbackVehicleCmd, this, _1));
+  emergency_sub_ = create_subscription<autoware_vehicle_msgs::msg::VehicleEmergencyStamped>(
+    "/control/emergency_cmd", 1, std::bind(&PacmodInterface::callbackEmergencyCmd, this, _1));
 
   // From pacmod
 
@@ -162,8 +162,8 @@ void PacmodInterface::callbackActuationCmd(
   actuation_cmd_ptr_ = msg;
 }
 
-void PacmodInterface::callbackVehicleCmd(
-  const autoware_vehicle_msgs::msg::VehicleCommand::ConstSharedPtr msg)
+void PacmodInterface::callbackEmergencyCmd(
+  const autoware_vehicle_msgs::msg::VehicleEmergencyStamped::ConstSharedPtr msg)
 {
   is_emergency_ = (msg->emergency == 1);
 }

--- a/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
@@ -165,7 +165,7 @@ void PacmodInterface::callbackActuationCmd(
 void PacmodInterface::callbackEmergencyCmd(
   const autoware_vehicle_msgs::msg::VehicleEmergencyStamped::ConstSharedPtr msg)
 {
-  is_emergency_ = (msg->emergency == 1);
+  is_emergency_ = msg->emergency;
 }
 
 void PacmodInterface::callbackControlCmd(

--- a/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
@@ -244,22 +244,10 @@ void PacmodInterface::callbackPacmodRpt(
     autoware_auto_vehicle_msgs::msg::ControlModeReport control_mode_msg;
     control_mode_msg.stamp = header.stamp;
 
-    if (!global_rpt->enabled) {
-      control_mode_msg.mode = autoware_auto_vehicle_msgs::msg::ControlModeReport::MANUAL;
-    } else if (is_pacmod_enabled_) {
+    if (global_rpt->enabled && is_pacmod_enabled_) {
       control_mode_msg.mode = autoware_auto_vehicle_msgs::msg::ControlModeReport::AUTONOMOUS;
     } else {
-      const bool is_pedal_enable = (accel_rpt_ptr_->enabled && brake_rpt_ptr_->enabled);
-      const bool is_steer_enable = steer_wheel_rpt_ptr_->enabled;
-      if (is_pedal_enable) {
-        control_mode_msg.mode = autoware_auto_vehicle_msgs::msg::ControlModeReport::AUTONOMOUS;
-      } else if (is_steer_enable) {
-        control_mode_msg.mode = autoware_auto_vehicle_msgs::msg::ControlModeReport::AUTONOMOUS;
-      } else {
-        RCLCPP_ERROR(
-          get_logger(), "global_rpt is enable, but steer & pedal is disabled. Set mode = MANUAL");
-        control_mode_msg.mode = autoware_auto_vehicle_msgs::msg::ControlModeReport::MANUAL;
-      }
+      control_mode_msg.mode = autoware_auto_vehicle_msgs::msg::ControlModeReport::MANUAL;
     }
 
     control_mode_pub_->publish(control_mode_msg);


### PR DESCRIPTION
## Description

.auto porting of as
**pacmode_interfaceのみの変更**

**PR外のTODO**
autoware_vehicle_msgs/msg/の以下が残り
- ActuationCommandStamped
- ActuationStatusStamped
- VehicleEmergencyStamped


**turn signal**
前提として、もともとは
- .iv: ウィンカーをつけてる間トピックを送り続ける
- .auto: ウィンカーをつける瞬間、消す瞬間のみトピックを送る

auto_msgsはウィンカーをつける、消す瞬間に対応するためにENABLE/DISABLE形式

堀部さん高木さんの議論のもと、今回の変更では.ivの今までのロジック・実装(ウィンカーをつけている間トピックを送り続ける)は変えずに、auto_msgsのENABLE/DISABLEを使う(ENABLE=ONの状態, DISABLE=OFFの状態として扱う)

**トピック名の変更**
https://docs.google.com/presentation/d/1sPrbHOoptGKNibJzgC_OENAy_EZHrWvjJCNDESUJtiw/edit#slide=id.g1009677dfcf_2_0


NOTE:
turn_signal -> turn_indicators + hazard_lights

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
