### PR TITLE
update iv_msgs -> auto_msgs in planning readme

### DIFF
--- a/planning/scenario_planning/common/external_velocity_limit_selector/README.md
+++ b/planning/scenario_planning/common/external_velocity_limit_selector/README.md
@@ -61,16 +61,16 @@ Example:
 Example:
   ### Input
 
-  | Name                 | Type                                                | Description          |
-  | -------------------- | --------------------------------------------------- | -------------------- |
-  | `~/input/trajectory` | `autoware_planning_msgs::msg::Trajectory`           | reference trajectory |
-  | `~/input/obstacles`  | `autoware_perception_msgs::msg::DynamicObjectArray` | obstacles            |
+  | Name                 | Type                                                   | Description          |
+  | -------------------- | ------------------------------------------------------ | -------------------- |
+  | `~/input/trajectory` | `autoware_auto_planning_msgs::msg::Trajectory`         | reference trajectory |
+  | `~/input/obstacles`  | `autoware_auto_perception_msgs::msg::PredictedObjects` | obstacles            |
 
   ### Output
 
-  | Name                  | Type                                      | Description         |
-  | --------------------- | ----------------------------------------- | ------------------- |
-  | `~/output/trajectory` | `autoware_planning_msgs::msg::Trajectory` | modified trajectory |
+  | Name                  | Type                                           | Description         |
+  | --------------------- | ---------------------------------------------- | ------------------- |
+  | `~/output/trajectory` | `autoware_auto_planning_msgs::msg::Trajectory` | modified trajectory |
 -->
 
 ## Parameters

--- a/planning/scenario_planning/common/motion_velocity_smoother/README.md
+++ b/planning/scenario_planning/common/motion_velocity_smoother/README.md
@@ -90,7 +90,7 @@ After the optimization, a resampling called `post resampling` is performed befor
 | ------------------------------------------ | ---------------------------------------- | ----------------------------- |
 | `~/input/trajectory`                       | `autoware_auto_planning_msgs/Trajectory` | Reference trajectory          |
 | `/planning/scenario_planning/max_velocity` | `std_msgs/Float32`                       | External velocity limit [m/s] |
-| `/localization/odometry`                   | `nav_msgs/Odometry`                      | Current odometry              |
+| `/localization/kinematic_state`            | `nav_msgs/Odometry`                      | Current odometry              |
 | `/tf`                                      | `tf2_msgs/TFMessage`                     | TF                            |
 | `/tf_static`                               | `tf2_msgs/TFMessage`                     | TF static                     |
 

--- a/planning/scenario_planning/common/motion_velocity_smoother/README.md
+++ b/planning/scenario_planning/common/motion_velocity_smoother/README.md
@@ -86,13 +86,13 @@ After the optimization, a resampling called `post resampling` is performed befor
 
 ### Input
 
-| Name                                       | Type                                | Description                   |
-| ------------------------------------------ | ----------------------------------- | ----------------------------- |
-| `~/input/trajectory`                       | `autoware_planning_msgs/Trajectory` | Reference trajectory          |
-| `/planning/scenario_planning/max_velocity` | `std_msgs/Float32`                  | External velocity limit [m/s] |
-| `/localization/odometry`                   | `nav_msgs/Odometry`                 | Current odometry              |
-| `/tf`                                      | `tf2_msgs/TFMessage`                | TF                            |
-| `/tf_static`                               | `tf2_msgs/TFMessage`                | TF static                     |
+| Name                                       | Type                                     | Description                   |
+| ------------------------------------------ | ---------------------------------------- | ----------------------------- |
+| `~/input/trajectory`                       | `autoware_auto_planning_msgs/Trajectory` | Reference trajectory          |
+| `/planning/scenario_planning/max_velocity` | `std_msgs/Float32`                       | External velocity limit [m/s] |
+| `/localization/odometry`                   | `nav_msgs/Odometry`                      | Current odometry              |
+| `/tf`                                      | `tf2_msgs/TFMessage`                     | TF                            |
+| `/tf_static`                               | `tf2_msgs/TFMessage`                     | TF static                     |
 
 ### Output
 

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/README.md
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/README.md
@@ -9,10 +9,10 @@ Only position and orientation of trajectory are calculated in this module, and v
 
 ### input
 
-| Name             | Type                                          | Description                                        |
-| ---------------- | --------------------------------------------- | -------------------------------------------------- |
-| `reference_path` | autoware_auto_planning_msgs/Path              | Reference path and the corresponding drivable area |
-| `objects`        | autoware_auto_perception_msgs/DetectedObjects | Recognized objects around the vehicle              |
+| Name             | Type                                           | Description                                        |
+| ---------------- | ---------------------------------------------- | -------------------------------------------------- |
+| `reference_path` | autoware_auto_planning_msgs/Path               | Reference path and the corresponding drivable area |
+| `objects`        | autoware_auto_perception_msgs/PredictedObjects | Recognized objects around the vehicle              |
 
 ### output
 

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/README.md
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/README.md
@@ -21,20 +21,20 @@ When the deceleration section is inserted, the start point of the section is ins
 
 ## Input topics
 
-| Name                        | Type                                         | Description         |
-| --------------------------- | -------------------------------------------- | ------------------- |
-| `~/input/pointcloud`        | sensor_msgs::PointCloud2                     | obstacle pointcloud |
-| `~/input/trajectory`        | autoware_planning_msgs::msg::Trajectory      | trajectory          |
-| `~/input/vector_map`        | autoware_lanelet2_msgs::MapBin               | vector map          |
-| `~/input/odometry`          | nav_msgs::Odometry                           | vehicle velocity    |
-| `~input/dynamic_objects`    | autoware_perception_msgs::DynamicObjectArray | dynamic objects     |
-| `~/input/expand_stop_range` | autoware_planning_msgs::msg::ExpandStopRange | expand stop range   |
+| Name                        | Type                                            | Description         |
+| --------------------------- | ----------------------------------------------- | ------------------- |
+| `~/input/pointcloud`        | sensor_msgs::PointCloud2                        | obstacle pointcloud |
+| `~/input/trajectory`        | autoware_auto_planning_msgs::msg::Trajectory    | trajectory          |
+| `~/input/vector_map`        | autoware_auto_mapping_msgs::HADMapBin           | vector map          |
+| `~/input/odometry`          | nav_msgs::Odometry                              | vehicle velocity    |
+| `~input/dynamic_objects`    | autoware_auto_perception_msgs::PredictedObjects | dynamic objects     |
+| `~/input/expand_stop_range` | autoware_planning_msgs::msg::ExpandStopRange    | expand stop range   |
 
 ## Output topics
 
 | Name                   | Type                                    | Description                            |
 | ---------------------- | --------------------------------------- | -------------------------------------- |
-| `~output/trajectory`   | autoware_planning_msgs::Trajectory      | trajectory to be followed              |
+| `~output/trajectory`   | autoware_auto_planning_msgs::Trajectory | trajectory to be followed              |
 | `~output/stop_reasons` | autoware_planning_msgs::StopReasonArray | reasons that cause the vehicle to stop |
 
 ## Modules

--- a/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/README.md
+++ b/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/README.md
@@ -60,7 +60,7 @@ As mentioned in stop condition section, it prevents chattering by changing thres
 
 | Name                       | Type                                           | Description              |
 | -------------------------- | ---------------------------------------------- | ------------------------ |
-| `~/output/trajectory`      | `autoware_planning_msgs/Trajectory`            | Modified trajectory      |
+| `~/output/trajectory`      | `autoware_auto_planning_msgs/Trajectory`       | Modified trajectory      |
 | `~/output/no_start_reason` | `diagnostic_msgs::msg::DiagnosticStatus`       | No start reason          |
 | `~/output/stop_reasons`    | `autoware_planning_msgs::msg::StopReasonArray` | Stop reasons             |
 | `~/debug/marker`           | `visualization_msgs::msg::MarkerArray`         | Marker for visualization |

--- a/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/README.md
+++ b/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/README.md
@@ -47,14 +47,14 @@ As mentioned in stop condition section, it prevents chattering by changing thres
 
 ### Input
 
-| Name                                     | Type                                                     | Description          |
-| ---------------------------------------- | -------------------------------------------------------- | -------------------- |
-| `~/input/trajectory`                     | `autoware_auto_planning_msgs::msg::Trajectory`           | Reference trajectory |
-| `/sensing/lidar/no_ground/pointcloud`    | `sensor_msgs::msg::PointCloud2`                          | No ground pointcloud |
-| `/perception/object_recognition/objects` | `autoware_auto_perception_msgs::msg::DynamicObjectArray` | Dynamic objects      |
-| `/localization/kinematic_state`          | `nav_msgs::msg::Odometry`                                | Current twist        |
-| `/tf`                                    | `tf2_msgs::msg::TFMessage`                               | TF                   |
-| `/tf_static`                             | `tf2_msgs::msg::TFMessage`                               | TF static            |
+| Name                                     | Type                                                   | Description          |
+| ---------------------------------------- | ------------------------------------------------------ | -------------------- |
+| `~/input/trajectory`                     | `autoware_auto_planning_msgs::msg::Trajectory`         | Reference trajectory |
+| `/sensing/lidar/no_ground/pointcloud`    | `sensor_msgs::msg::PointCloud2`                        | No ground pointcloud |
+| `/perception/object_recognition/objects` | `autoware_auto_perception_msgs::msg::PredictedObjects` | Dynamic objects      |
+| `/localization/kinematic_state`          | `nav_msgs::msg::Odometry`                              | Current twist        |
+| `/tf`                                    | `tf2_msgs::msg::TFMessage`                             | TF                   |
+| `/tf_static`                             | `tf2_msgs::msg::TFMessage`                             | TF static            |
 
 ### Output
 

--- a/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/surround_obstacle_checker-design.ja.md
+++ b/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/surround_obstacle_checker-design.ja.md
@@ -46,14 +46,14 @@ Stop condition の項で述べたように、状態によって障害物判定�
 
 ### Input
 
-| Name                                     | Type                                                     | Description          |
-| ---------------------------------------- | -------------------------------------------------------- | -------------------- |
-| `~/input/trajectory`                     | `autoware_auto_planning_msgs::msg::Trajectory`           | Reference trajectory |
-| `/sensing/lidar/no_ground/pointcloud`    | `sensor_msgs::msg::PointCloud2`                          | No ground pointcloud |
-| `/perception/object_recognition/objects` | `autoware_auto_perception_msgs::msg::DynamicObjectArray` | Dynamic objects      |
-| `/localization/twist`                    | `geometry_msgs::msg::TwistStamped`                       | Current twist        |
-| `/tf`                                    | `tf2_msgs::msg::TFMessage`                               | TF                   |
-| `/tf_static`                             | `tf2_msgs::msg::TFMessage`                               | TF static            |
+| Name                                     | Type                                                   | Description          |
+| ---------------------------------------- | ------------------------------------------------------ | -------------------- |
+| `~/input/trajectory`                     | `autoware_auto_planning_msgs::msg::Trajectory`         | Reference trajectory |
+| `/sensing/lidar/no_ground/pointcloud`    | `sensor_msgs::msg::PointCloud2`                        | No ground pointcloud |
+| `/perception/object_recognition/objects` | `autoware_auto_perception_msgs::msg::PredictedObjects` | Dynamic objects      |
+| `/localization/kinematic_state`          | `geometry_msgs::msg::TwistStamped`                     | Current twist        |
+| `/tf`                                    | `tf2_msgs::msg::TFMessage`                             | TF                   |
+| `/tf_static`                             | `tf2_msgs::msg::TFMessage`                             | TF static            |
 
 ### Output
 

--- a/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/surround_obstacle_checker-design.ja.md
+++ b/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/surround_obstacle_checker-design.ja.md
@@ -51,7 +51,7 @@ Stop condition の項で述べたように、状態によって障害物判定�
 | `~/input/trajectory`                     | `autoware_auto_planning_msgs::msg::Trajectory`         | Reference trajectory |
 | `/sensing/lidar/no_ground/pointcloud`    | `sensor_msgs::msg::PointCloud2`                        | No ground pointcloud |
 | `/perception/object_recognition/objects` | `autoware_auto_perception_msgs::msg::PredictedObjects` | Dynamic objects      |
-| `/localization/kinematic_state`          | `geometry_msgs::msg::TwistStamped`                     | Current twist        |
+| `/localization/kinematic_state`          | `nav_msgs::msg::Odometry`                              | Current twist        |
 | `/tf`                                    | `tf2_msgs::msg::TFMessage`                             | TF                   |
 | `/tf_static`                             | `tf2_msgs::msg::TFMessage`                             | TF static            |
 

--- a/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/surround_obstacle_checker-design.ja.md
+++ b/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/surround_obstacle_checker-design.ja.md
@@ -46,20 +46,20 @@ Stop condition の項で述べたように、状態によって障害物判定�
 
 ### Input
 
-| Name                                     | Type                                                | Description          |
-| ---------------------------------------- | --------------------------------------------------- | -------------------- |
-| `~/input/trajectory`                     | `autoware_planning_msgs::msg::Trajectory`           | Reference trajectory |
-| `/sensing/lidar/no_ground/pointcloud`    | `sensor_msgs::msg::PointCloud2`                     | No ground pointcloud |
-| `/perception/object_recognition/objects` | `autoware_perception_msgs::msg::DynamicObjectArray` | Dynamic objects      |
-| `/localization/twist`                    | `geometry_msgs::msg::TwistStamped`                  | Current twist        |
-| `/tf`                                    | `tf2_msgs::msg::TFMessage`                          | TF                   |
-| `/tf_static`                             | `tf2_msgs::msg::TFMessage`                          | TF static            |
+| Name                                     | Type                                                     | Description          |
+| ---------------------------------------- | -------------------------------------------------------- | -------------------- |
+| `~/input/trajectory`                     | `autoware_auto_planning_msgs::msg::Trajectory`           | Reference trajectory |
+| `/sensing/lidar/no_ground/pointcloud`    | `sensor_msgs::msg::PointCloud2`                          | No ground pointcloud |
+| `/perception/object_recognition/objects` | `autoware_auto_perception_msgs::msg::DynamicObjectArray` | Dynamic objects      |
+| `/localization/twist`                    | `geometry_msgs::msg::TwistStamped`                       | Current twist        |
+| `/tf`                                    | `tf2_msgs::msg::TFMessage`                               | TF                   |
+| `/tf_static`                             | `tf2_msgs::msg::TFMessage`                               | TF static            |
 
 ### Output
 
 | Name                       | Type                                           | Description              |
 | -------------------------- | ---------------------------------------------- | ------------------------ |
-| `~/output/trajectory`      | `autoware_planning_msgs/Trajectory`            | Modified trajectory      |
+| `~/output/trajectory`      | `autoware_auto_planning_msgs/Trajectory`       | Modified trajectory      |
 | `~/output/no_start_reason` | `diagnostic_msgs::msg::DiagnosticStatus`       | No start reason          |
 | `~/output/stop_reasons`    | `autoware_planning_msgs::msg::StopReasonArray` | Stop reasons             |
 | `~/debug/marker`           | `visualization_msgs::msg::MarkerArray`         | Marker for visualization |

--- a/planning/scenario_planning/scenario_selector/README.md
+++ b/planning/scenario_planning/scenario_selector/README.md
@@ -6,21 +6,21 @@
 
 ### Input topics
 
-| Name                             | Type                               | Description                                           |
-| -------------------------------- | ---------------------------------- | ----------------------------------------------------- |
-| `~input/lane_driving/trajectory` | autoware_planning_msgs::Trajectory | trajectory of LaneDriving scenario                    |
-| `~input/parking/trajectory`      | autoware_planning_msgs::Trajectory | trajectory of Parking scenario                        |
-| `~input/lanelet_map`             | autoware_lanelet2_msgs::MapBin     |                                                       |
-| `~input/route`                   | autoware_planning_msgs::Route      | route and goal pose                                   |
-| `~input/odometry`                | nav_msgs::Odometry                 | for checking whether vehicle is stopped               |
-| `is_parking_completed`           | bool (implemented as rosparam)     | whether all split trajectory of Parking are published |
+| Name                             | Type                                     | Description                                           |
+| -------------------------------- | ---------------------------------------- | ----------------------------------------------------- |
+| `~input/lane_driving/trajectory` | autoware_auto_planning_msgs::Trajectory  | trajectory of LaneDriving scenario                    |
+| `~input/parking/trajectory`      | autoware_auto_planning_msgs::Trajectory  | trajectory of Parking scenario                        |
+| `~input/lanelet_map`             | autoware_auto_mapping_msgs::HADMapBin    |                                                       |
+| `~input/route`                   | autoware_auto_planning_msgs::HADMapRoute | route and goal pose                                   |
+| `~input/odometry`                | nav_msgs::Odometry                       | for checking whether vehicle is stopped               |
+| `is_parking_completed`           | bool (implemented as rosparam)           | whether all split trajectory of Parking are published |
 
 ### Output topics
 
-| Name                 | Type                               | Description                                    |
-| -------------------- | ---------------------------------- | ---------------------------------------------- |
-| `~output/scenario`   | autoware_planning_msgs::Scenario   | current scenario and scenarios to be activated |
-| `~output/trajectory` | autoware_planning_msgs::Trajectory | trajectory to be followed                      |
+| Name                 | Type                                    | Description                                    |
+| -------------------- | --------------------------------------- | ---------------------------------------------- |
+| `~output/scenario`   | autoware_planning_msgs::Scenario        | current scenario and scenarios to be activated |
+| `~output/trajectory` | autoware_auto_planning_msgs::Trajectory | trajectory to be followed                      |
 
 ### Output TFs
 


### PR DESCRIPTION
## Description

In planning README.md, I updated iv_msgs -> auto_msgs

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
