### PR TITLE
[autoware_vehicle_rviz_plugin/route_handler/simple_planning_simulator]fix some packages

### DIFF
--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.cpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.cpp
@@ -89,7 +89,7 @@ void ConsoleMeterDisplay::update(float wall_dt, float ros_dt)
     if (!last_msg_ptr_) {
       return;
     }
-    linear_x = last_msg_ptr_->twist.linear.x;
+    linear_x = last_msg_ptr_->longitudinal_velocity;
   }
 
   QColor background_color;
@@ -152,7 +152,7 @@ void ConsoleMeterDisplay::update(float wall_dt, float ros_dt)
 }
 
 void ConsoleMeterDisplay::processMessage(
-  const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg_ptr)
+  const autoware_auto_vehicle_msgs::msg::VelocityReport::ConstSharedPtr msg_ptr)
 {
   if (!isEnabled()) {
     return;

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/console_meter.hpp
@@ -27,12 +27,13 @@
 #include <rviz_common/properties/int_property.hpp>
 #include <rviz_common/ros_topic_display.hpp>
 
-#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
 #endif
 
 namespace rviz_plugins
 {
-class ConsoleMeterDisplay : public rviz_common::RosTopicDisplay<geometry_msgs::msg::TwistStamped>
+class ConsoleMeterDisplay
+: public rviz_common::RosTopicDisplay<autoware_auto_vehicle_msgs::msg::VelocityReport>
 {
   Q_OBJECT
 
@@ -49,7 +50,8 @@ private Q_SLOTS:
 
 protected:
   void update(float wall_dt, float ros_dt) override;
-  void processMessage(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg_ptr) override;
+  void processMessage(
+    const autoware_auto_vehicle_msgs::msg::VelocityReport::ConstSharedPtr msg_ptr) override;
   jsk_rviz_plugins::OverlayObject::Ptr overlay_;
   rviz_common::properties::ColorProperty * property_text_color_;
   rviz_common::properties::IntProperty * property_left_;
@@ -83,7 +85,7 @@ private:
   Arc outer_arc_;
 
   std::mutex mutex_;
-  geometry_msgs::msg::TwistStamped::ConstSharedPtr last_msg_ptr_;
+  autoware_auto_vehicle_msgs::msg::VelocityReport::ConstSharedPtr last_msg_ptr_;
 };
 
 }  // namespace rviz_plugins

--- a/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.hpp
+++ b/common/util/rviz_plugins/autoware_vehicle_rviz_plugin/src/tools/velocity_history.hpp
@@ -22,7 +22,7 @@
 #include <rviz_common/ros_topic_display.hpp>
 #include <rviz_common/validate_floats.hpp>
 
-#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
 
 #include <OgreColourValue.h>
 #include <OgreManualObject.h>
@@ -35,7 +35,8 @@
 
 namespace rviz_plugins
 {
-class VelocityHistoryDisplay : public rviz_common::RosTopicDisplay<geometry_msgs::msg::TwistStamped>
+class VelocityHistoryDisplay
+: public rviz_common::RosTopicDisplay<autoware_auto_vehicle_msgs::msg::VelocityReport>
 {
   Q_OBJECT
 
@@ -51,7 +52,8 @@ private Q_SLOTS:
 
 protected:
   void update(float wall_dt, float ros_dt) override;
-  void processMessage(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg_ptr) override;
+  void processMessage(
+    const autoware_auto_vehicle_msgs::msg::VelocityReport::ConstSharedPtr msg_ptr) override;
   std::unique_ptr<Ogre::ColourValue> setColorDependsOnVelocity(
     const double vel_max, const double cmd_vel);
   std::unique_ptr<Ogre::ColourValue> gradation(
@@ -65,9 +67,11 @@ protected:
   rviz_common::properties::FloatProperty * property_vel_max_;
 
 private:
-  std::deque<std::tuple<geometry_msgs::msg::TwistStamped::ConstSharedPtr, Ogre::Vector3>>
+  std::deque<
+    std::tuple<autoware_auto_vehicle_msgs::msg::VelocityReport::ConstSharedPtr, Ogre::Vector3>>
     histories_;
-  bool validateFloats(const geometry_msgs::msg::TwistStamped::ConstSharedPtr & msg_ptr);
+  bool validateFloats(
+    const autoware_auto_vehicle_msgs::msg::VelocityReport::ConstSharedPtr & msg_ptr);
   std::mutex mutex_;
 };
 

--- a/planning/mission_planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.cpp
+++ b/planning/mission_planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.cpp
@@ -276,6 +276,7 @@ autoware_auto_planning_msgs::msg::HADMapRoute MissionPlannerLanelet2::planRoute(
       return route_msg;
     }
     // create local route sections
+    route_handler_.setRouteLanelets(path_lanelets);
     const auto local_route_sections = route_handler_.createMapSegments(path_lanelets);
     route_sections = combineConsecutiveRouteSections(route_sections, local_route_sections);
   }

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -63,6 +63,7 @@ public:
   // non-const methods
   void setMap(const HADMapBin & map_msg);
   void setRoute(const HADMapRoute & route_msg);
+  void setRouteLanelets(const lanelet::ConstLanelets & path_lanelets);
   void setPullOverGoalPose(
     const lanelet::ConstLanelet target_lane, const double vehicle_width, const double margin);
 
@@ -146,7 +147,6 @@ private:
   bool is_handler_ready_{false};
 
   // non-const methods
-  void setRouteLanelets(const lanelet::ConstLanelets & path_lanelets);
   void setLaneletsFromRouteMsg();
 
   // const methods

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -59,7 +59,7 @@ def generate_launch_description():
             ('output/steering', '/vehicle/status/steering'),
             ('output/gear_report', '/vehicle/status/shift'),
             ('output/control_mode_report', '/vehicle/status/control_mode'),
-            ('/initialpose', '/localization/initialpose'),
+            ('/initialpose', '/initialpose'),
         ]
     )
 


### PR DESCRIPTION
## Description

Fix some packages

<!-- Describe what this PR changes. -->

## Review Procedure

comment out Control module in planning_simulator.launch.xml
comment out scenario_planning_module in planning.launch.xml
comment out dummy_perception module in simulator.launch.xml
change simple_planning_simulator.launch.xml to simple_planning_simulator.launch.py in simulator.launch.xml

```
diff --git a/autoware_launch/launch/planning_simulator.launch.xml b/autoware_launch/launch/planning_simulator.launch.xml
index 8738ca0..4ed7d38 100644
--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -46,12 +46,6 @@
   <include file="$(find-pkg-share planning_launch)/launch/planning.launch.xml">
   </include>
 
-  <!-- Control -->
-  <include file="$(find-pkg-share control_launch)/launch/control.launch.py">
-    <!-- options for lateral_controller_mode: mpc_follower, pure_pursuit -->
-    <arg name="lateral_controller_mode" value="mpc_follower" />
-  </include>
-
   <!-- Autoware API -->
   <include file="$(find-pkg-share autoware_api_launch)/launch/autoware_api.launch.xml">
     <arg name="init_simulator_pose" value="true"/>
diff --git a/planning_launch/launch/planning.launch.xml b/planning_launch/launch/planning.launch.xml
index 640b3a2..1772c9f 100644
--- a/planning_launch/launch/planning.launch.xml
+++ b/planning_launch/launch/planning.launch.xml
@@ -10,11 +10,11 @@
     </group>
 
     <!-- scenario planning module -->
-    <group>
+    <!-- <group>
       <push-ros-namespace namespace="scenario_planning"/>
       <include file="$(find-pkg-share planning_launch)/launch/scenario_planning/scenario_planning.launch.xml">
       </include>
-    </group>
+    </group> -->
 
     <!-- planning error monitor -->
     <group>
diff --git a/simulator_launch/launch/simulator.launch.xml b/simulator_launch/launch/simulator.launch.xml
index 0253d8d..e9479e4 100644
--- a/simulator_launch/launch/simulator.launch.xml
+++ b/simulator_launch/launch/simulator.launch.xml
@@ -16,19 +16,19 @@
   </group>
 
   <!-- Dummy Perception -->
-  <group unless="$(var scenario_simulation)">
+  <!-- <group unless="$(var scenario_simulation)">
     <include file="$(find-pkg-share dummy_perception_publisher)/launch/dummy_perception_publisher.launch.xml">
       <arg name="real" value="$(var perception/enable_detection_failure)"/>
       <arg name="use_object_recognition" value="$(var perception/enable_object_recognition)"/>
       <arg name="visible_range" value="$(var sensing/visible_range)"/>
     </include>
-  </group>
+  </group> -->
 
   <!-- Simulator model -->
   <group if="$(var vehicle_simulation)">
     <group unless="$(var scenario_simulation)">
       <arg name="simulator_model" default="$(var vehicle_model_pkg)/config/simulator_model.param.yaml" description="path to the file of simulator model"/>
-      <include file="$(find-pkg-share simple_planning_simulator)/launch/simple_planning_simulator.launch.xml">
+      <include file="$(find-pkg-share simple_planning_simulator)/launch/simple_planning_simulator.launch.py">
         <arg name="simulator_model" value="$(var simulator_model)"/>
         <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
       </include>

```

$ros2 launch autoware_launch planning_simulator.launch.xml vehicle_id:=default vehicle_model:=[VEHICLE_MODEL] sensor_model:=[SENSOR_MODEL] map_path:=[MAP_PATH]
set start position and goal position
![image](https://user-images.githubusercontent.com/59680180/141407727-0f356f0d-323d-427c-8d75-931bcb4405b7.png)

(Please check that no modules die.)

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [pull request guidelines][pull-request-guidelines]
- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
