### PR TITLE
Fix message interface and tests of 'trajectory_follower_nodes'

### DIFF
--- a/control/trajectory_follower/include/trajectory_follower/mpc.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc.hpp
@@ -37,7 +37,7 @@
 #include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
 #include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_vehicle_msgs/msg/vehicle_kinematic_state.hpp"
+#include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "common/types.hpp"
 #include "geometry/common_2d.hpp"
 #include "geometry_msgs/msg/pose.hpp"
@@ -187,7 +187,7 @@ private:
    */
   bool8_t getData(
     const trajectory_follower::MPCTrajectory & traj,
-    const autoware_auto_vehicle_msgs::msg::VehicleKinematicState & current_steer,
+    const autoware_auto_vehicle_msgs::msg::SteeringReport & current_steer,
     const geometry_msgs::msg::Pose & current_pose,
     MPCData * data);
   /**
@@ -369,7 +369,7 @@ public:
    * @param [out] diagnostic diagnostic msg to be filled-out
    */
   bool8_t calculateMPC(
-    const autoware_auto_vehicle_msgs::msg::VehicleKinematicState & current_steer,
+    const autoware_auto_vehicle_msgs::msg::SteeringReport & current_steer,
     const float64_t current_velocity,
     const geometry_msgs::msg::Pose & current_pose,
     autoware_auto_control_msgs::msg::AckermannLateralCommand & ctrl_cmd,

--- a/control/trajectory_follower/src/mpc.cpp
+++ b/control/trajectory_follower/src/mpc.cpp
@@ -37,7 +37,7 @@ using namespace std::chrono_literals;
 using ::motion::motion_common::to_angle;
 
 bool8_t MPC::calculateMPC(
-  const autoware_auto_vehicle_msgs::msg::VehicleKinematicState & current_steer,
+  const autoware_auto_vehicle_msgs::msg::SteeringReport & current_steer,
   const float64_t current_velocity,
   const geometry_msgs::msg::Pose & current_pose,
   autoware_auto_control_msgs::msg::AckermannLateralCommand & ctrl_cmd,
@@ -260,7 +260,7 @@ void MPC::setReferenceTrajectory(
 
 bool8_t MPC::getData(
   const trajectory_follower::MPCTrajectory & traj,
-  const autoware_auto_vehicle_msgs::msg::VehicleKinematicState & current_steer,
+  const autoware_auto_vehicle_msgs::msg::SteeringReport & current_steer,
   const geometry_msgs::msg::Pose & current_pose,
   MPCData * data)
 {
@@ -278,7 +278,7 @@ bool8_t MPC::getData(
 
   /* get data */
   data->nearest_idx = static_cast<int64_t>(nearest_idx);
-  data->steer = static_cast<float64_t>(current_steer.state.front_wheel_angle_rad);
+  data->steer = static_cast<float64_t>(current_steer.steering_tire_angle);
   data->lateral_err = trajectory_follower::MPCUtils::calcLateralError(
     current_pose,
     data->nearest_pose);
@@ -288,8 +288,7 @@ bool8_t MPC::getData(
 
   /* get predicted steer */
   if (!m_steer_prediction_prev) {
-    m_steer_prediction_prev = std::make_shared<float64_t>(
-      current_steer.state.front_wheel_angle_rad);
+    m_steer_prediction_prev = std::make_shared<float64_t>(current_steer.steering_tire_angle);
   }
   data->predicted_steer = calcSteerPrediction();
   *m_steer_prediction_prev = data->predicted_steer;

--- a/control/trajectory_follower/test/test_mpc.cpp
+++ b/control/trajectory_follower/test/test_mpc.cpp
@@ -26,7 +26,7 @@
 #include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
-#include "autoware_auto_vehicle_msgs/msg/vehicle_kinematic_state.hpp"
+#include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "common/types.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "gtest/gtest.h"
@@ -39,7 +39,7 @@ using autoware::common::types::bool8_t;
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
 typedef autoware_auto_planning_msgs::msg::Trajectory Trajectory;
 typedef autoware_auto_planning_msgs::msg::TrajectoryPoint TrajectoryPoint;
-typedef autoware_auto_vehicle_msgs::msg::VehicleKinematicState VehicleKinematicState;
+typedef autoware_auto_vehicle_msgs::msg::SteeringReport SteeringReport;
 typedef geometry_msgs::msg::Pose Pose;
 typedef geometry_msgs::msg::PoseStamped PoseStamped;
 typedef autoware_auto_control_msgs::msg::AckermannLateralCommand AckermannLateralCommand;
@@ -52,7 +52,7 @@ protected:
   // Test inputs
   Trajectory dummy_straight_trajectory;
   Trajectory dummy_right_turn_trajectory;
-  VehicleKinematicState neutral_steer;
+  SteeringReport neutral_steer;
   Pose pose_zero;
   PoseStamped::SharedPtr pose_zero_ptr;
   float64_t default_velocity = 1.0;
@@ -151,7 +151,7 @@ protected:
     p.longitudinal_velocity_mps = 1.0f;
     dummy_right_turn_trajectory.points.push_back(p);
 
-    neutral_steer.state.front_wheel_angle_rad = 0.0;
+    neutral_steer.steering_tire_angle = 0.0;
     pose_zero.position.x = 0.0;
     pose_zero.position.y = 0.0;
     pose_zero_ptr = std::make_shared<PoseStamped>();

--- a/control/trajectory_follower_nodes/CMakeLists.txt
+++ b/control/trajectory_follower_nodes/CMakeLists.txt
@@ -67,19 +67,16 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
   # Unit tests
-  #set(TRAJECTORY_FOLLOWER_NODES_TEST test_trajectory_follower_nodes)
-  ## TODO(Maxime CLEMENT) : setting domain id is a workaround to avoid tests from other packages interfering with these tests
-  #ament_add_gtest(${TRAJECTORY_FOLLOWER_NODES_TEST}
-  #  test/trajectory_follower_test_utils.hpp
-  #  test/test_latlon_muxer_node.cpp
-  #  test/test_lateral_controller_node.cpp
-  #  test/test_longitudinal_controller_node.cpp
-  #  ENV
-  #  ROS_DOMAIN_ID=40
-  #)
-  #ament_target_dependencies(${TRAJECTORY_FOLLOWER_NODES_TEST} fake_test_node)
-  #autoware_set_compile_options(${TRAJECTORY_FOLLOWER_NODES_TEST})
-  #target_link_libraries(${TRAJECTORY_FOLLOWER_NODES_TEST} ${LATLON_MUXER_NODE} ${LATERAL_CONTROLLER_NODE} ${LONGITUDINAL_CONTROLLER_NODE})
+  set(TRAJECTORY_FOLLOWER_NODES_TEST test_trajectory_follower_nodes)
+  ament_add_gtest(${TRAJECTORY_FOLLOWER_NODES_TEST}
+    test/trajectory_follower_test_utils.hpp
+    test/test_latlon_muxer_node.cpp
+    test/test_lateral_controller_node.cpp
+    test/test_longitudinal_controller_node.cpp
+  )
+  ament_target_dependencies(${TRAJECTORY_FOLLOWER_NODES_TEST} fake_test_node)
+  autoware_set_compile_options(${TRAJECTORY_FOLLOWER_NODES_TEST})
+  target_link_libraries(${TRAJECTORY_FOLLOWER_NODES_TEST} ${LATLON_MUXER_NODE} ${LATERAL_CONTROLLER_NODE} ${LONGITUDINAL_CONTROLLER_NODE})
 
   #find_package(autoware_testing REQUIRED)
   #add_smoke_test(${PROJECT_NAME} ${LATLON_MUXER_NODE}_exe PARAM_FILENAME latlon_muxer_defaults.yaml)

--- a/control/trajectory_follower_nodes/include/trajectory_follower_nodes/lateral_controller_node.hpp
+++ b/control/trajectory_follower_nodes/include/trajectory_follower_nodes/lateral_controller_node.hpp
@@ -46,6 +46,7 @@
 #include "tf2/utils.h"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
 
 
 namespace autoware
@@ -133,6 +134,7 @@ private:
 
   //!< @brief buffer for transforms
   tf2::BufferCore m_tf_buffer{tf2::BUFFER_CORE_DEFAULT_CACHE_TIME};
+  tf2_ros::TransformListener m_tf_listener{m_tf_buffer};
 
   //!< initialize timer to work in real, simulation, and replay
   void initTimer(float64_t period_s);
@@ -145,18 +147,6 @@ private:
    * @brief set m_current_trajectory with received message
    */
   void onTrajectory(const autoware_auto_planning_msgs::msg::Trajectory::SharedPtr);
-
-  /**
-   * @brief callback for TF message
-   * @param [in] msg transform message
-   */
-  void callbackTF(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg);
-
-  /**
-   * @brief callback for static TF message
-   * @param [in] msg static transform message
-   */
-  void callbackStaticTF(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg);
 
   /**
    * @brief update current_pose from tf

--- a/control/trajectory_follower_nodes/include/trajectory_follower_nodes/lateral_controller_node.hpp
+++ b/control/trajectory_follower_nodes/include/trajectory_follower_nodes/lateral_controller_node.hpp
@@ -35,7 +35,8 @@
 #include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
 #include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_vehicle_msgs/msg/vehicle_kinematic_state.hpp"
+#include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
+#include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
 #include "common/types.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -82,8 +83,10 @@ private:
     m_pub_diagnostic;
   //!< @brief topic subscription for reference waypoints
   rclcpp::Subscription<autoware_auto_planning_msgs::msg::Trajectory>::SharedPtr m_sub_ref_path;
-  //!< @brief subscription for current state
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VehicleKinematicState>::SharedPtr m_sub_steering;
+  //!< @brief subscription for current velocity
+  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VehicleOdometry>::SharedPtr m_sub_odometry;
+  //!< @brief subscription for current steering
+  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::SteeringReport>::SharedPtr m_sub_steering;
   //!< @brief timer to update after a given interval
   rclcpp::TimerBase::SharedPtr m_timer;
   //!< @brief subscription for transform messages
@@ -112,8 +115,10 @@ private:
 
   //!< @brief measured pose
   geometry_msgs::msg::PoseStamped::SharedPtr m_current_pose_ptr;
-  //!< @brief measured state
-  autoware_auto_vehicle_msgs::msg::VehicleKinematicState::SharedPtr m_current_state_ptr;
+  //!< @brief measured velocity
+  autoware_auto_vehicle_msgs::msg::VehicleOdometry::SharedPtr m_current_odometry_ptr;
+  //!< @brief measured steering
+  autoware_auto_vehicle_msgs::msg::SteeringReport::SharedPtr m_current_steering_ptr;
   //!< @brief reference trajectory
   autoware_auto_planning_msgs::msg::Trajectory::SharedPtr
     m_current_trajectory_ptr;
@@ -165,9 +170,14 @@ private:
   bool8_t checkData() const;
 
   /**
-   * @brief set current_state with received message
+   * @brief set current_velocity with received message
    */
-  void onState(const autoware_auto_vehicle_msgs::msg::VehicleKinematicState::SharedPtr msg);
+  void onOdometry(const autoware_auto_vehicle_msgs::msg::VehicleOdometry::SharedPtr msg);
+
+  /**
+   * @brief set current_steering with received message
+   */
+  void onSteering(const autoware_auto_vehicle_msgs::msg::SteeringReport::SharedPtr msg);
 
   /**
    * @brief publish control command

--- a/control/trajectory_follower_nodes/include/trajectory_follower_nodes/longitudinal_controller_node.hpp
+++ b/control/trajectory_follower_nodes/include/trajectory_follower_nodes/longitudinal_controller_node.hpp
@@ -22,7 +22,7 @@
 
 #include "autoware_auto_control_msgs/msg/longitudinal_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_vehicle_msgs/msg/vehicle_kinematic_state.hpp"
+#include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
 #include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/Geometry"
@@ -80,8 +80,8 @@ private:
   };
 
   // ros variables
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VehicleKinematicState>::SharedPtr
-    m_sub_current_state;
+  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VehicleOdometry>::SharedPtr
+    m_sub_current_velocity;
   rclcpp::Subscription<autoware_auto_planning_msgs::msg::Trajectory>::SharedPtr m_sub_trajectory;
   rclcpp::Publisher<autoware_auto_control_msgs::msg::LongitudinalCommand>::SharedPtr m_pub_control_cmd;
   rclcpp::Publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>::SharedPtr m_pub_slope;
@@ -97,8 +97,8 @@ private:
     const std::vector<rclcpp::Parameter> & parameters);
 
   // pointers for ros topic
-  std::shared_ptr<autoware_auto_vehicle_msgs::msg::VehicleKinematicState> m_current_state_ptr{nullptr};
-  std::shared_ptr<autoware_auto_vehicle_msgs::msg::VehicleKinematicState> m_prev_state_ptr{nullptr};
+  std::shared_ptr<autoware_auto_vehicle_msgs::msg::VehicleOdometry> m_current_velocity_ptr{nullptr};
+  std::shared_ptr<autoware_auto_vehicle_msgs::msg::VehicleOdometry> m_prev_velocity_ptr{nullptr};
   std::shared_ptr<autoware_auto_planning_msgs::msg::Trajectory> m_trajectory_ptr{nullptr};
 
   // vehicle info
@@ -203,8 +203,8 @@ private:
    * @brief set current and previous velocity with received message
    * @param [in] msg current state message
    */
-  void callbackCurrentState(
-    const autoware_auto_vehicle_msgs::msg::VehicleKinematicState::ConstSharedPtr msg);
+  void callbackCurrentVelocity(
+    const autoware_auto_vehicle_msgs::msg::VehicleOdometry::ConstSharedPtr msg);
 
   /**
    * @brief set reference trajectory with received message

--- a/control/trajectory_follower_nodes/include/trajectory_follower_nodes/longitudinal_controller_node.hpp
+++ b/control/trajectory_follower_nodes/include/trajectory_follower_nodes/longitudinal_controller_node.hpp
@@ -33,6 +33,7 @@
 #include "tf2/utils.h"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
 #include "trajectory_follower/debug_values.hpp"
 #include "trajectory_follower/longitudinal_controller_utils.hpp"
 #include "trajectory_follower/lowpass_filter.hpp"
@@ -91,6 +92,7 @@ private:
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr m_tf_sub;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr m_tf_static_sub;
   tf2::BufferCore m_tf_buffer{tf2::BUFFER_CORE_DEFAULT_CACHE_TIME};
+  tf2_ros::TransformListener m_tf_listener{m_tf_buffer};
 
   OnSetParametersCallbackHandle::SharedPtr m_set_param_res;
   rcl_interfaces::msg::SetParametersResult paramCallback(
@@ -216,18 +218,6 @@ private:
    * @brief compute control command, and publish periodically
    */
   void callbackTimerControl();
-
-  /**
-   * @brief callback for TF message
-   * @param [in] msg transform message
-   */
-  void callbackTF(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg);
-
-  /**
-   * @brief callback for static TF message
-   * @param [in] msg static transform message
-   */
-  void callbackStaticTF(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg);
 
   /**
    * @brief calculate data for controllers whose type is ControlData

--- a/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
+++ b/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
@@ -161,11 +161,6 @@ LateralController::LateralController(const rclcpp::NodeOptions & node_options)
   m_sub_odometry = create_subscription<autoware_auto_vehicle_msgs::msg::VehicleOdometry>(
     "input/current_odometry", rclcpp::QoS{1}, std::bind(
       &LateralController::onOdometry, this, _1));
-  m_tf_sub = create_subscription<tf2_msgs::msg::TFMessage>(
-    "input/tf", rclcpp::QoS{1}, std::bind(&LateralController::callbackTF, this, _1));
-  m_tf_static_sub = create_subscription<tf2_msgs::msg::TFMessage>(
-    "input/tf_static", rclcpp::QoS{1}.transient_local(),
-    std::bind(&LateralController::callbackStaticTF, this, _1));
 
   // TODO(Frederik.Beaujean) ctor is too long, should factor out parameter declarations
   declareMPCparameters();
@@ -286,24 +281,6 @@ void LateralController::onTrajectory(const autoware_auto_planning_msgs::msg::Tra
   m_mpc.setReferenceTrajectory(
     *msg, m_traj_resample_dist, m_enable_path_smoothing, m_path_filter_moving_ave_num,
     m_enable_yaw_recalculation, m_curvature_smoothing_num, m_current_pose_ptr);
-}
-
-void LateralController::callbackTF(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg)
-{
-  for (const auto & tf : msg->transforms) {
-    if (!m_tf_buffer.setTransform(tf, "external", false)) {
-      RCLCPP_WARN(get_logger(), "Warning: tf2::BufferCore::setTransform failed");
-    }
-  }
-}
-
-void LateralController::callbackStaticTF(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg)
-{
-  for (const auto & tf : msg->transforms) {
-    if (!m_tf_buffer.setTransform(tf, "external", true)) {
-      RCLCPP_WARN(get_logger(), "Warning: tf2::BufferCore::setTransform failed");
-    }
-  }
 }
 
 bool8_t LateralController::updateCurrentPose()

--- a/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
+++ b/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
@@ -155,9 +155,12 @@ LateralController::LateralController(const rclcpp::NodeOptions & node_options)
   m_sub_ref_path = create_subscription<autoware_auto_planning_msgs::msg::Trajectory>(
     "input/reference_trajectory", rclcpp::QoS{1},
     std::bind(&LateralController::onTrajectory, this, _1));
-  m_sub_steering = create_subscription<autoware_auto_vehicle_msgs::msg::VehicleKinematicState>(
-    "input/current_kinematic_state", rclcpp::QoS{1}, std::bind(
-      &LateralController::onState, this, _1));
+  m_sub_steering = create_subscription<autoware_auto_vehicle_msgs::msg::SteeringReport>(
+    "input/current_steering", rclcpp::QoS{1}, std::bind(
+      &LateralController::onSteering, this, _1));
+  m_sub_odometry = create_subscription<autoware_auto_vehicle_msgs::msg::VehicleOdometry>(
+    "input/current_odometry", rclcpp::QoS{1}, std::bind(
+      &LateralController::onOdometry, this, _1));
   m_tf_sub = create_subscription<tf2_msgs::msg::TFMessage>(
     "input/tf", rclcpp::QoS{1}, std::bind(&LateralController::callbackTF, this, _1));
   m_tf_static_sub = create_subscription<tf2_msgs::msg::TFMessage>(
@@ -201,7 +204,7 @@ void LateralController::onTimer()
   }
 
   const bool8_t is_mpc_solved = m_mpc.calculateMPC(
-    *m_current_state_ptr, m_current_state_ptr->state.longitudinal_velocity_mps,
+    *m_current_steering_ptr, m_current_odometry_ptr->velocity_mps,
     m_current_pose_ptr->pose, ctrl_cmd, predicted_traj, diagnostic);
 
   if (isStoppedState()) {
@@ -244,10 +247,17 @@ bool8_t LateralController::checkData() const
     return false;
   }
 
-  if (!m_current_state_ptr) {
+  if (!m_current_odometry_ptr) {
     RCLCPP_DEBUG(
-      get_logger(), "waiting data. current_state = %d",
-      m_current_state_ptr != nullptr);
+      get_logger(), "waiting data. current_velocity = %d",
+      m_current_odometry_ptr != nullptr);
+    return false;
+  }
+
+  if (!m_current_steering_ptr) {
+    RCLCPP_DEBUG(
+      get_logger(), "waiting data. current_steering = %d",
+      m_current_steering_ptr != nullptr);
     return false;
   }
 
@@ -324,9 +334,14 @@ bool8_t LateralController::updateCurrentPose()
   return true;
 }
 
-void LateralController::onState(const autoware_auto_vehicle_msgs::msg::VehicleKinematicState::SharedPtr msg)
+void LateralController::onOdometry(const autoware_auto_vehicle_msgs::msg::VehicleOdometry::SharedPtr msg)
 {
-  m_current_state_ptr = msg;
+  m_current_odometry_ptr = msg;
+}
+
+void LateralController::onSteering(const autoware_auto_vehicle_msgs::msg::SteeringReport::SharedPtr msg)
+{
+  m_current_steering_ptr = msg;
 }
 
 autoware_auto_control_msgs::msg::AckermannLateralCommand LateralController::getStopControlCommand() const
@@ -340,7 +355,7 @@ autoware_auto_control_msgs::msg::AckermannLateralCommand LateralController::getS
 autoware_auto_control_msgs::msg::AckermannLateralCommand LateralController::getInitialControlCommand() const
 {
   autoware_auto_control_msgs::msg::AckermannLateralCommand cmd;
-  cmd.steering_tire_angle = m_current_state_ptr->state.front_wheel_angle_rad;
+  cmd.steering_tire_angle = m_current_steering_ptr->steering_tire_angle;
   cmd.steering_tire_rotation_rate = 0.0;
   return cmd;
 }
@@ -364,7 +379,7 @@ bool8_t LateralController::isStoppedState() const
   }
   RCLCPP_DEBUG(get_logger(), "stop_dist = %f release stopping.", dist);
 
-  const float64_t current_vel = m_current_state_ptr->state.longitudinal_velocity_mps;
+  const float64_t current_vel = m_current_odometry_ptr->velocity_mps;
   const float64_t target_vel =
     m_current_trajectory_ptr->points.at(static_cast<size_t>(nearest)).longitudinal_velocity_mps;
   if (

--- a/control/trajectory_follower_nodes/src/longitudinal_controller_node.cpp
+++ b/control/trajectory_follower_nodes/src/longitudinal_controller_node.cpp
@@ -169,9 +169,9 @@ LongitudinalController::LongitudinalController(const rclcpp::NodeOptions & node_
   m_min_pitch_rad = declare_parameter<float64_t>("min_pitch_rad");  // [rad]
 
   // subscriber, publisher
-  m_sub_current_state = create_subscription<autoware_auto_vehicle_msgs::msg::VehicleKinematicState>(
+  m_sub_current_velocity = create_subscription<autoware_auto_vehicle_msgs::msg::VehicleOdometry>(
     "input/current_state", rclcpp::QoS{1},
-    std::bind(&LongitudinalController::callbackCurrentState, this, _1));
+    std::bind(&LongitudinalController::callbackCurrentVelocity, this, _1));
   m_sub_trajectory = create_subscription<autoware_auto_planning_msgs::msg::Trajectory>(
     "input/current_trajectory", rclcpp::QoS{1},
     std::bind(&LongitudinalController::callbackTrajectory, this, _1));
@@ -210,13 +210,13 @@ LongitudinalController::LongitudinalController(const rclcpp::NodeOptions & node_
   m_lpf_acc = std::make_shared<trajectory_follower::LowpassFilter1d>(0.0, 0.2);
 }
 
-void LongitudinalController::callbackCurrentState(
-  const autoware_auto_vehicle_msgs::msg::VehicleKinematicState::ConstSharedPtr msg)
+void LongitudinalController::callbackCurrentVelocity(
+  const autoware_auto_vehicle_msgs::msg::VehicleOdometry::ConstSharedPtr msg)
 {
-  if (m_current_state_ptr) {
-    m_prev_state_ptr = m_current_state_ptr;
+  if (m_current_velocity_ptr) {
+    m_prev_velocity_ptr = m_current_velocity_ptr;
   }
-  m_current_state_ptr = std::make_shared<autoware_auto_vehicle_msgs::msg::VehicleKinematicState>(*msg);
+  m_current_velocity_ptr = std::make_shared<autoware_auto_vehicle_msgs::msg::VehicleOdometry>(*msg);
 }
 
 void LongitudinalController::callbackTrajectory(
@@ -383,24 +383,21 @@ void LongitudinalController::callbackTimerControl()
 {
   // wait for initial pointers
   if (
-    !m_current_state_ptr || !m_prev_state_ptr || !m_trajectory_ptr ||
-    !m_tf_buffer.canTransform(
-      m_trajectory_ptr->header.frame_id,
-      m_current_state_ptr->header.frame_id,
-      tf2::TimePointZero))
-  {
+    !m_current_velocity_ptr || !m_prev_velocity_ptr || !m_trajectory_ptr ||
+    !m_tf_buffer.canTransform(m_trajectory_ptr->header.frame_id, "base_link", tf2::TimePointZero)) {
     return;
   }
 
-  // transform state to the same frame as the trajectory
-  geometry_msgs::msg::TransformStamped tf = m_tf_buffer.lookupTransform(
-    m_trajectory_ptr->header.frame_id,
-    m_current_state_ptr->header.frame_id,
-    tf2::TimePointZero);
-  autoware_auto_planning_msgs::msg::TrajectoryPoint current_state_tf;
-  ::motion::motion_common::doTransform(m_current_state_ptr->state, current_state_tf, tf);
+  // get current ego pose
+  geometry_msgs::msg::TransformStamped tf =
+    m_tf_buffer.lookupTransform(m_trajectory_ptr->header.frame_id, "base_link", tf2::TimePointZero);
+
   // calculate current pose and control data
-  geometry_msgs::msg::Pose current_pose = current_state_tf.pose;
+  geometry_msgs::msg::Pose current_pose;
+  current_pose.position.x = tf.transform.translation.x;
+  current_pose.position.y = tf.transform.translation.y;
+  current_pose.position.z = tf.transform.translation.z;
+  current_pose.orientation = tf.transform.rotation;
 
   const auto control_data = getControlData(current_pose);
 
@@ -714,15 +711,15 @@ float64_t LongitudinalController::getDt()
 
 LongitudinalController::Motion LongitudinalController::getCurrentMotion() const
 {
-  const float64_t dv = m_current_state_ptr->state.longitudinal_velocity_mps -
-    m_prev_state_ptr->state.longitudinal_velocity_mps;
+  const float64_t dv = m_current_velocity_ptr->velocity_mps -
+    m_prev_velocity_ptr->velocity_mps;
   const float64_t dt =
     std::max(
-    (rclcpp::Time(m_current_state_ptr->header.stamp) -
-    rclcpp::Time(m_prev_state_ptr->header.stamp)).seconds(), 1e-03);
+    (rclcpp::Time(m_current_velocity_ptr->stamp) -
+    rclcpp::Time(m_prev_velocity_ptr->stamp)).seconds(), 1e-03);
   const float64_t accel = dv / dt;
 
-  const float64_t current_vel = m_current_state_ptr->state.longitudinal_velocity_mps;
+  const float64_t current_vel = m_current_velocity_ptr->velocity_mps;
   const float64_t current_acc = m_lpf_acc->filter(accel);
 
   return Motion{current_vel, current_acc};


### PR DESCRIPTION
## Description

<!-- Describe what this PR changes. -->
This PR changes the interface of nodes in the `trajectory_follower_nodes` package to use `VehicleOdometry` and `SteeringReport` instead of `VehicleKinematicState`.
The tests of the `trajectory_follower` and `trajectory_follower_nodes` are also restored and fixed.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
