### PR TITLE
Auto/fix perception viz

### DIFF
--- a/common/util/rviz_plugins/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/util/rviz_plugins/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -181,6 +181,7 @@ visualization_msgs::msg::Marker::SharedPtr get_uuid_marker_ptr(
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->type = Marker::TEXT_VIEW_FACING;
+  marker_ptr->ns = std::string("uuid");
   marker_ptr->text = uuid.substr(0, 4);
   marker_ptr->action = Marker::MODIFY;
   marker_ptr->scale.z = 0.5;

--- a/perception/object_recognition/detection/detection_by_tracker/launch/detection_by_tracker.launch.xml
+++ b/perception/object_recognition/detection/detection_by_tracker/launch/detection_by_tracker.launch.xml
@@ -18,21 +18,4 @@
     <remap from="~/input/initial_objects" to="initial_objects"/>
     <remap from="~/output" to="$(var output)"/>
   </node>
-
-  <!-- visualization -->
-  <group>
-    <include file="$(find-pkg-share dynamic_object_visualization)/launch/dynamic_object_visualizer.launch.xml">
-      <arg name="input" value="objects"/>
-      <arg name="with_feature" value="true"/>
-      <arg name="only_known_objects" value="true"/>
-    </include>
-  </group>
-  <group>
-    <include file="$(find-pkg-share dynamic_object_visualization)/launch/dynamic_object_visualizer.launch.xml">
-      <arg name="input" value="initial_objects"/>
-      <arg name="with_feature" value="true"/>
-      <arg name="only_known_objects" value="false"/>
-    </include>
-  </group>
-
 </launch>


### PR DESCRIPTION
## Description

<!-- Describe what this PR changes. -->
- fix (about perception rviz plugin)

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
