### PR TITLE
[motion_velocity_smoother]consider upper size of trajectory points

### DIFF
--- a/planning/scenario_planning/common/motion_velocity_smoother/src/resample.cpp
+++ b/planning/scenario_planning/common/motion_velocity_smoother/src/resample.cpp
@@ -254,6 +254,8 @@ boost::optional<TrajectoryPoints> resampleTrajectory(
     constexpr double ep_dist = 1.0E-3;
     if (autoware_utils::calcDistance2d(output->back(), input.back()) < ep_dist) {
       output->back() = input.back();
+    } else if (output->size() >= output->max_size()) {
+      output->back() = input.back();
     } else {
       output->push_back(input.back());
     }

--- a/planning/scenario_planning/common/motion_velocity_smoother/src/trajectory_utils.cpp
+++ b/planning/scenario_planning/common/motion_velocity_smoother/src/trajectory_utils.cpp
@@ -137,6 +137,9 @@ boost::optional<TrajectoryPoints> extractPathAroundIndex(
   TrajectoryPoints extracted_traj{};
   for (size_t i = behind_index; i < ahead_index + 1; ++i) {
     extracted_traj.push_back(trajectory.at(i));
+    if (extracted_traj.size() >= extracted_traj.max_size()) {
+      break;
+    }
   }
 
   return boost::optional<TrajectoryPoints>(extracted_traj);
@@ -331,6 +334,10 @@ boost::optional<TrajectoryPoints> applyLinearInterpolation(
     point.heading_rate_rps = taz_p->at(i);
     point.acceleration_mps2 = alx_p->at(i);
     out_trajectory.push_back(point);
+
+    if (out_trajectory.size() >= out_trajectory.max_size()) {
+      break;
+    }
   }
   return boost::optional<TrajectoryPoints>(out_trajectory);
 }

--- a/planning/scenario_planning/common/motion_velocity_smoother/src/trajectory_utils.cpp
+++ b/planning/scenario_planning/common/motion_velocity_smoother/src/trajectory_utils.cpp
@@ -136,10 +136,10 @@ boost::optional<TrajectoryPoints> extractPathAroundIndex(
   // extract trajectory
   TrajectoryPoints extracted_traj{};
   for (size_t i = behind_index; i < ahead_index + 1; ++i) {
-    extracted_traj.push_back(trajectory.at(i));
     if (extracted_traj.size() >= extracted_traj.max_size()) {
       break;
     }
+    extracted_traj.push_back(trajectory.at(i));
   }
 
   return boost::optional<TrajectoryPoints>(extracted_traj);


### PR DESCRIPTION
## Description

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
