### PR TITLE
[latlon muxer] fix gtest

### DIFF
--- a/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
+++ b/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
@@ -185,7 +185,7 @@ LateralController::~LateralController()
 void LateralController::onTimer()
 {
   if (!checkData() || !updateCurrentPose()) {
-    publishCtrlCmd(getStopControlCommand());    
+    publishCtrlCmd(getStopControlCommand());
     return;
   }
 

--- a/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
+++ b/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
@@ -185,7 +185,7 @@ LateralController::~LateralController()
 void LateralController::onTimer()
 {
   if (!checkData() || !updateCurrentPose()) {
-    publishCtrlCmd(getStopControlCommand());
+    publishCtrlCmd(getStopControlCommand());    
     return;
   }
 

--- a/control/trajectory_follower_nodes/test/test_lateral_controller_node.cpp
+++ b/control/trajectory_follower_nodes/test/test_lateral_controller_node.cpp
@@ -278,8 +278,8 @@ TEST_F(FakeNodeFixture, right_turn)
   steer_msg.steering_tire_angle = 0.0;
   odom_pub->publish(odom_msg);
   steer_pub->publish(steer_msg);
-  
-  test_utils::warmStart(node);
+
+  test_utils::spinWhile(node);
   test_utils::waitForMessage(node, this, received_lateral_command);
   ASSERT_TRUE(received_lateral_command);
   EXPECT_LT(cmd_msg->steering_tire_angle, 0.0f);
@@ -350,7 +350,7 @@ TEST_F(FakeNodeFixture, left_turn)
   odom_pub->publish(odom_msg);
   steer_pub->publish(steer_msg);
 
-  test_utils::warmStart(node);
+  test_utils::spinWhile(node);
   test_utils::waitForMessage(node, this, received_lateral_command);
   ASSERT_TRUE(received_lateral_command);
   EXPECT_GT(cmd_msg->steering_tire_angle, 0.0f);
@@ -422,7 +422,7 @@ TEST_F(FakeNodeFixture, stopped)
   odom_pub->publish(odom_msg);
   steer_pub->publish(steer_msg);
 
-  test_utils::warmStart(node);
+  test_utils::spinWhile(node);
   test_utils::waitForMessage(node, this, received_lateral_command);
   ASSERT_TRUE(received_lateral_command);
   EXPECT_EQ(cmd_msg->steering_tire_angle, steer_msg.steering_tire_angle);

--- a/control/trajectory_follower_nodes/test/test_lateral_controller_node.cpp
+++ b/control/trajectory_follower_nodes/test/test_lateral_controller_node.cpp
@@ -278,7 +278,8 @@ TEST_F(FakeNodeFixture, right_turn)
   steer_msg.steering_tire_angle = 0.0;
   odom_pub->publish(odom_msg);
   steer_pub->publish(steer_msg);
-
+  
+  test_utils::warmStart(node);
   test_utils::waitForMessage(node, this, received_lateral_command);
   ASSERT_TRUE(received_lateral_command);
   EXPECT_LT(cmd_msg->steering_tire_angle, 0.0f);
@@ -349,6 +350,7 @@ TEST_F(FakeNodeFixture, left_turn)
   odom_pub->publish(odom_msg);
   steer_pub->publish(steer_msg);
 
+  test_utils::warmStart(node);
   test_utils::waitForMessage(node, this, received_lateral_command);
   ASSERT_TRUE(received_lateral_command);
   EXPECT_GT(cmd_msg->steering_tire_angle, 0.0f);
@@ -420,6 +422,7 @@ TEST_F(FakeNodeFixture, stopped)
   odom_pub->publish(odom_msg);
   steer_pub->publish(steer_msg);
 
+  test_utils::warmStart(node);
   test_utils::waitForMessage(node, this, received_lateral_command);
   ASSERT_TRUE(received_lateral_command);
   EXPECT_EQ(cmd_msg->steering_tire_angle, steer_msg.steering_tire_angle);

--- a/control/trajectory_follower_nodes/test/trajectory_follower_test_utils.hpp
+++ b/control/trajectory_follower_nodes/test/trajectory_follower_test_utils.hpp
@@ -69,7 +69,7 @@ inline geometry_msgs::msg::TransformStamped getDummyTransform()
   transform_stamped.child_frame_id = "base_link";
   return transform_stamped;
 }
-// TODO modify the controller nodes so that they does not publish topics when data is not ready.
+// TODO(Horibe): modify the controller nodes so that they does not publish topics when data is not ready.
 // then, remove this function.
 template <typename T>
 inline void spinWhile(T &node){

--- a/control/trajectory_follower_nodes/test/trajectory_follower_test_utils.hpp
+++ b/control/trajectory_follower_nodes/test/trajectory_follower_test_utils.hpp
@@ -69,9 +69,10 @@ inline geometry_msgs::msg::TransformStamped getDummyTransform()
   transform_stamped.child_frame_id = "base_link";
   return transform_stamped;
 }
-// TODO remove this to modify latlon muxer publish topic only when data is ready
+// TODO modify the controller nodes so that they does not publish topics when data is not ready.
+// then, remove this function.
 template <typename T>
-inline void warmStart(T &node){
+inline void spinWhile(T &node){
     for (size_t i = 0; i < 10; i++) {
       rclcpp::spin_some(node);  
       const auto dt{std::chrono::milliseconds{100LL}};

--- a/control/trajectory_follower_nodes/test/trajectory_follower_test_utils.hpp
+++ b/control/trajectory_follower_nodes/test/trajectory_follower_test_utils.hpp
@@ -69,6 +69,15 @@ inline geometry_msgs::msg::TransformStamped getDummyTransform()
   transform_stamped.child_frame_id = "base_link";
   return transform_stamped;
 }
+// TODO remove this to modify latlon muxer publish topic only when data is ready
+template <typename T>
+inline void warmStart(T &node){
+    for (size_t i = 0; i < 10; i++) {
+      rclcpp::spin_some(node);  
+      const auto dt{std::chrono::milliseconds{100LL}};
+      std::this_thread::sleep_for(dt);
+  }
+}
 }  // namespace test_utils
 
 #endif  // TRAJECTORY_FOLLOWER_TEST_UTILS_HPP_


### PR DESCRIPTION
## Description

sometimes CI fail by pub/sub and is depend on machine power
```
1: [ RUN      ] FakeNodeFixture.longitudinal_emergency
Error: OR] [1637094206.261132890] [longitudinal_controller]: [Emergency stop] vel: 0.000, acc: -0.100
1: [       OK ] FakeNodeFixture.longitudinal_emergency (232 ms)
1: [ RUN      ] FakeNodeFixture.longitudinal_set_param_smoke_test
1: [       OK ] FakeNodeFixture.longitudinal_set_param_smoke_test (138 ms)
1: [----------] 17 tests from FakeNodeFixture (6915 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 17 tests from 1 test suite ran. (6916 ms total)
1: [  PASSED  ] 16 tests.
1: [  FAILED  ] 1 test, listed below:
1: [  FAILED  ] FakeNodeFixture.stopped
1: 
1:  1 FAILED TEST
1:   YOU HAVE 1 DISABLED TEST
1: 
```


fix gtest for latlon muxer


## Review Procedure

colcon test pass

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
