### PR TITLE
[behavior velocity planner]fix occlusion spot

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot_in_private_road.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot_in_private_road.cpp
@@ -100,7 +100,7 @@ bool OcclusionSpotInPrivateModule::modifyPathVelocity(
   RCLCPP_DEBUG_STREAM_THROTTLE(
     logger_, *clock_, 3000, "num possible collision:" << possible_collisions.size());
   behavior_velocity_planner::occlusion_spot_utils::calcSlowDownPointsForPossibleCollision(
-    closest_idx, interp_path, offset_from_ego_to_target, possible_collisions);
+    closest_idx, *path, offset_from_ego_to_target, possible_collisions);
   // apply safe velocity using ebs and pbs deceleration
   applySafeVelocityConsideringPossibleCollison(
     path, possible_collisions, ego_velocity, param_.private_road, param_);

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot_in_public_road.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot_in_public_road.cpp
@@ -89,7 +89,7 @@ bool OcclusionSpotInPublicModule::modifyPathVelocity(
     possible_collisions, interp_path, param_, offset_from_ego_to_target, dynamic_obj_arr_ptr);
   // set orientation to each possible collision
   behavior_velocity_planner::occlusion_spot_utils::calcSlowDownPointsForPossibleCollision(
-    closest_idx, interp_path, offset_from_ego_to_target, possible_collisions);
+    closest_idx, *path, offset_from_ego_to_target, possible_collisions);
   // apply safe velocity using ebs and pbs deceleration
   applySafeVelocityConsideringPossibleCollison(
     path, possible_collisions, ego_velocity, param_.public_road, param_);


### PR DESCRIPTION
## Description
Fix occlusion spot.
1. In calcSlowDownPointsForPossibleCollision, longitudinal speeds of path are used. But all longitudinal speeds of `interp_path` are 0 m/s because these are not interpolated.
2. In calcSlowDownPointsForPossibleCollision, closest_idx is used. This closest_idx is calculated using not `interp path` but `path`. 

Therefore, `path` should be used here.

<!-- Describe what this PR changes. -->

## Review Procedure
Check following.


Before merging this PR.
Occlusion spot inserts stop point(= point with 0 m/s speed)
![image](https://user-images.githubusercontent.com/59680180/143181767-d0b4286a-14cb-4266-9630-b3df0cdfeb7f.png)

Occulsion spot inserts deceleration point
![image](https://user-images.githubusercontent.com/59680180/143181862-f5fda865-9a30-4d41-8e23-02753b2d50d6.png)


<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
