### PR TITLE
Fix unstable test in trajectory_follower_nodes

### DIFF
--- a/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
+++ b/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
@@ -265,7 +265,7 @@ void LateralController::onTrajectory(
   m_current_trajectory_ptr = msg;
 
   if (!m_current_pose_ptr && !updateCurrentPose()) {
-    RCLCPP_DEBUG(get_logger(), "Current pose is invalid!!");
+    RCLCPP_DEBUG(get_logger(), "Current pose is not received yet.");
     return;
   }
 

--- a/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
+++ b/control/trajectory_follower_nodes/src/lateral_controller_node.cpp
@@ -181,7 +181,6 @@ LateralController::~LateralController()
 void LateralController::onTimer()
 {
   if (!checkData() || !updateCurrentPose()) {
-    publishCtrlCmd(getStopControlCommand());
     return;
   }
 
@@ -266,6 +265,7 @@ void LateralController::onTrajectory(
   m_current_trajectory_ptr = msg;
 
   if (!m_current_pose_ptr && !updateCurrentPose()) {
+    RCLCPP_DEBUG(get_logger(), "Current pose is invalid!!");
     return;
   }
 

--- a/control/trajectory_follower_nodes/test/test_lateral_controller_node.cpp
+++ b/control/trajectory_follower_nodes/test/test_lateral_controller_node.cpp
@@ -123,6 +123,10 @@ TEST_F(FakeNodeFixture, empty_trajectory)
   geometry_msgs::msg::TransformStamped transform = test_utils::getDummyTransform();
   transform.header.stamp = node->now();
   br->sendTransform(transform);
+
+  // Spin for transform to be published
+  test_utils::spinWhile(node);
+
   // Empty trajectory: expect a stopped command
   Trajectory traj_msg;
   traj_msg.header.stamp = node->now();
@@ -395,6 +399,10 @@ TEST_F(FakeNodeFixture, stopped)
   geometry_msgs::msg::TransformStamped transform = test_utils::getDummyTransform();
   transform.header.stamp = node->now();
   br->sendTransform(transform);
+
+  // Spin for transform to be published
+  test_utils::spinWhile(node);
+
   // Straight trajectory: expect no steering
   received_lateral_command = false;
   Trajectory traj_msg;

--- a/control/trajectory_follower_nodes/test/test_lateral_controller_node.cpp
+++ b/control/trajectory_follower_nodes/test/test_lateral_controller_node.cpp
@@ -290,8 +290,7 @@ TEST_F(FakeNodeFixture, right_turn)
   test_utils::waitForMessage(node, this, received_lateral_command);
   ASSERT_TRUE(received_lateral_command);
   EXPECT_LT(cmd_msg->steering_tire_angle, 0.0f);
-  // EXPECT_LT(cmd_msg->steering_tire_rotation_rate, 0.0f);  // NOTE: Is the statement correct?
-  // 1: Expected: (cmd_msg->steering_tire_rotation_rate) < (0.0f), actual: 5.55112e-16 vs 0
+  EXPECT_LT(cmd_msg->steering_tire_rotation_rate, 0.0f);
   EXPECT_GT(rclcpp::Time(cmd_msg->stamp), rclcpp::Time(traj_msg.header.stamp));
 }
 

--- a/control/trajectory_follower_nodes/test/trajectory_follower_test_utils.hpp
+++ b/control/trajectory_follower_nodes/test/trajectory_follower_test_utils.hpp
@@ -69,12 +69,13 @@ inline geometry_msgs::msg::TransformStamped getDummyTransform()
   transform_stamped.child_frame_id = "base_link";
   return transform_stamped;
 }
+
 // TODO(Horibe): modify the controller nodes so that they does not publish topics when data is not ready.
 // then, remove this function.
 template <typename T>
 inline void spinWhile(T &node){
     for (size_t i = 0; i < 10; i++) {
-      rclcpp::spin_some(node);  
+      rclcpp::spin_some(node);
       const auto dt{std::chrono::milliseconds{100LL}};
       std::this_thread::sleep_for(dt);
   }


### PR DESCRIPTION
## Description

<!-- Describe what this PR changes. -->
I was trying to figure out why gtests were sometimes failing on CI.
As a result, I determined that I need to fix the testing method.

The `trajectory_follower` assumes that there are enough messages in the `tf_buffer` before the trajectory message is received.
In our tests, we did not process messages using `spin_some()` after `sendTransform()`. This caused a problem where the order of arrival of the messages was swapped, especially under heavy CPU load, and the current position in `trajectory_follower` could not be obtained.
To fix this, I added a `spin_some()` and debug messages.

## Review Procedure

<!-- Explain how to review this PR. -->
To check this issue on local environment, follow this step:

Terminal1:
`stress-ng -c 8 -l 90`
This simulates 90% CPU load, each core. (note that my CPU has 8 cores. Edit this option if you need.)

Terminal2:
`colcon test --packages-select trajectory_follower_nodes --event-handlers console_cohesion+`

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [pull request guidelines][pull-request-guidelines]
- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [x] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
