### PR TITLE
auto/fix walkway dead lock

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
@@ -81,8 +81,7 @@ bool WalkwayModule::modifyPathVelocity(
     stop_factor.stop_factor_points.emplace_back(debug_data_.nearest_collision_point);
     planning_utils::appendStopReason(stop_factor, stop_reason);
 
-    // use arc length to identify if ego vehicle is in front of stop line or after passing stop
-    // line.
+    // use arc length to identify if ego vehicle is in front of walkway stop or not.
     const double distance = autoware_utils::calcSignedArcLength(
       path->points, planner_data_->current_pose.pose.position,
       debug_data_.first_stop_pose.position);
@@ -95,7 +94,7 @@ bool WalkwayModule::modifyPathVelocity(
       state_ = State::STOP;
     } else if (
       // If ego vehicle pass stop line without stopping then move state to surpassed
-      // Note : without this condition, vehicle stuck and never move.
+      // Note : without this condition, vehicle stuck and never restore to move by this state.
       distance < -distance_threshold &&
       planner_data_->isVehicleStopped(planner_param_.stop_duration_sec)) {
       state_ = State::SURPASSED;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
@@ -88,15 +88,13 @@ bool WalkwayModule::modifyPathVelocity(
     const double distance_threshold = 1.0;
     debug_data_.stop_judge_range = distance_threshold;
     if (
-      // If ego vehicle is inside distance threshold then move to stop state
       std::abs(distance) <= distance_threshold &&
       planner_data_->isVehicleStopped(planner_param_.stop_duration_sec)) {
+      // If ego vehicle is inside distance threshold then move to stop state
       state_ = State::STOP;
-    } else if (
+    } else if (distance < -distance_threshold) {
       // If ego vehicle pass stop line without stopping then move state to surpassed
       // Note : without this condition, vehicle stuck and never restore to move by this state.
-      distance < -distance_threshold &&
-      planner_data_->isVehicleStopped(planner_param_.stop_duration_sec)) {
       state_ = State::SURPASSED;
       RCLCPP_ERROR(logger_, "Failed to stop at walkway but ego stopped change state to SURPASSED");
     }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
@@ -88,15 +88,14 @@ bool WalkwayModule::modifyPathVelocity(
     const double distance_threshold = 1.0;
     debug_data_.stop_judge_range = distance_threshold;
     if (
-      std::abs(distance) <= distance_threshold &&
+      distance < distance_threshold &&
       planner_data_->isVehicleStopped(planner_param_.stop_duration_sec)) {
-      // If ego vehicle is inside distance threshold then move to stop state
+      // If ego vehicle is after walkway stop and stopped then move to stop state
       state_ = State::STOP;
-    } else if (distance < -distance_threshold) {
-      // If ego vehicle pass stop line without stopping then move state to surpassed
-      // Note : without this condition, vehicle stuck and never restore to move by this state.
-      state_ = State::SURPASSED;
-      RCLCPP_ERROR(logger_, "Failed to stop at walkway but ego stopped change state to SURPASSED");
+      if (distance < -distance_threshold) {
+        RCLCPP_ERROR(
+          logger_, "Failed to stop near walkway but ego stopped change state to STOPPED");
+      }
     }
     return true;
   } else if (state_ == State::STOP) {

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
@@ -94,7 +94,7 @@ bool WalkwayModule::modifyPathVelocity(
       state_ = State::STOP;
       if (distance < -distance_threshold) {
         RCLCPP_ERROR(
-          logger_, "Failed to stop near walkway but ego stopped change state to STOPPED");
+          logger_, "Failed to stop near walkway but ego stopped. Change state to STOPPED");
       }
     }
     return true;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -232,7 +232,7 @@ bool StopLineModule::modifyPathVelocity(
       state_ = State::STOPPED;
       if (signed_arc_dist_to_stop_point < -planner_param_.stop_check_dist) {
         RCLCPP_ERROR(
-          logger_, "Failed to stop near stop line but ego stopped change state to STOPPED");
+          logger_, "Failed to stop near stop line but ego stopped. Change state to STOPPED");
       }
     }
   } else if (state_ == State::STOPPED) {

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -230,6 +230,10 @@ bool StopLineModule::modifyPathVelocity(
       planner_data_->isVehicleStopped(planner_param_.stop_duration_sec)) {
       RCLCPP_INFO(logger_, "APPROACH -> STOPPED");
       state_ = State::STOPPED;
+      if (signed_arc_dist_to_stop_point < -planner_param_.stop_check_dist) {
+        RCLCPP_ERROR(
+          logger_, "Failed to stop near stop line but ego stopped change state to STOPPED");
+      }
     }
   } else if (state_ == State::STOPPED) {
     // Change state after vehicle departure

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <autoware_utils/trajectory/trajectory.hpp>
 #include <scene_module/stop_line/scene.hpp>
 #include <utilization/util.hpp>
 
@@ -85,72 +86,6 @@ boost::optional<StopLineModule::SegmentIndexWithOffset> findBackwardOffsetSegmen
 
   // No enough path length
   return {};
-}
-
-StopLineModule::SegmentIndexWithOffset findNearestSegment(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-  const geometry_msgs::msg::Point & point)
-{
-  std::vector<double> distances;
-  distances.reserve(path.points.size());
-
-  std::transform(
-    path.points.cbegin(), path.points.cend(), std::back_inserter(distances),
-    [&point](const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p) {
-      return planning_utils::calcDist2d(p.point.pose.position, point);
-    });
-
-  const auto min_itr = std::min_element(distances.cbegin(), distances.cend());
-  const auto min_idx = static_cast<size_t>(std::distance(distances.cbegin(), min_itr));
-
-  // Process boundary conditions
-  if (min_idx == 0 || min_idx == path.points.size() - 1) {
-    const size_t segment_idx = min_idx == 0 ? min_idx : min_idx - 1;
-
-    return StopLineModule::SegmentIndexWithOffset{
-      segment_idx, planning_utils::calcDist2d(path.points.at(segment_idx), point)};
-  }
-
-  // Process normal conditions(having previous and next points)
-  const auto & p_prev = path.points.at(min_idx - 1);
-  const auto d_prev = planning_utils::calcDist2d(p_prev, point);
-
-  const auto & p_next = path.points.at(min_idx + 1);
-  const auto d_next = planning_utils::calcDist2d(p_next, point);
-
-  const size_t segment_idx = (d_prev <= d_next) ? min_idx - 1 : min_idx;
-
-  return StopLineModule::SegmentIndexWithOffset{
-    segment_idx, planning_utils::calcDist2d(path.points.at(segment_idx), point)};
-}
-
-double calcSignedArcLength(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const size_t & idx_front,
-  const size_t & idx_back)
-{
-  // If flipped, reverse index and take negative
-  if (idx_front > idx_back) {
-    return -calcSignedArcLength(path, idx_back, idx_front);
-  }
-
-  double sum_length = 0.0;
-  for (size_t i = idx_front; i < idx_back; ++i) {
-    const auto & p1 = path.points.at(i).point.pose.position;
-    const auto & p2 = path.points.at(i + 1).point.pose.position;
-    sum_length += planning_utils::calcDist2d(p1, p2);
-  }
-
-  return sum_length;
-}
-
-double calcSignedArcLength(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-  const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2)
-{
-  const auto seg_1 = findNearestSegment(path, p1);
-  const auto seg_2 = findNearestSegment(path, p2);
-
-  return -seg_1.offset + calcSignedArcLength(path, seg_1.index, seg_2.index) + seg_2.offset;
 }
 
 }  // namespace
@@ -282,8 +217,8 @@ bool StopLineModule::modifyPathVelocity(
   const auto stop_pose_with_index = calcStopPose(*path, offset_segment);
 
   // Calc dist to stop pose
-  const double signed_arc_dist_to_stop_point = calcSignedArcLength(
-    *path, planner_data_->current_pose.pose.position, stop_pose_with_index->pose.position);
+  const double signed_arc_dist_to_stop_point = autoware_utils::calcSignedArcLength(
+    path->points, planner_data_->current_pose.pose.position, stop_pose_with_index->pose.position);
 
   if (state_ == State::APPROACH) {
     // Insert stop pose
@@ -291,7 +226,7 @@ bool StopLineModule::modifyPathVelocity(
 
     // Move to stopped state if stopped
     if (
-      std::abs(signed_arc_dist_to_stop_point) < planner_param_.stop_check_dist &&
+      signed_arc_dist_to_stop_point < planner_param_.stop_check_dist &&
       planner_data_->isVehicleStopped(planner_param_.stop_duration_sec)) {
       RCLCPP_INFO(logger_, "APPROACH -> STOPPED");
       state_ = State::STOPPED;


### PR DESCRIPTION
## Description

- bugfix

change walkway stop decision form relative distance to arc lane distance in order to avoid dead lock

Change
condition of walkway expired is "stop near walkway" to "stop near walkway" or "stop after walkway"

![Screenshot from 2021-11-29 16-28-58](https://user-images.githubusercontent.com/65527974/143825713-82ed3ba5-1d2e-4e6b-bd59-63462fa4d73f.png)

## Review Procedure

use rqt_publisher to manually override ego vehicle and see if walkway that ego vehicle passed is expired after stop
https://user-images.githubusercontent.com/65527974/143822890-b4ea74a5-cd57-41ce-8b34-6cfa798daeb5.mp4

see normal behavior is the same as before(stop line and walkway).
https://user-images.githubusercontent.com/65527974/143827037-5349a87b-1008-44a8-b651-ca71b27d131f.mp4


## Remarks

This kind of behavior change is going to added after December

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
