### PR TITLE
separate callback group to execute callbackInitialPose in parallel

### DIFF
--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -159,6 +159,7 @@ private:
   std::deque<geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr>
     initial_pose_msg_ptr_array_;
   std::mutex ndt_map_mtx_;
+  std::mutex initial_pose_array_mtx_;
 
   OMPParams omp_params_;
 

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/src/ndt_scan_matcher_node.cpp
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/src/ndt_scan_matcher_node.cpp
@@ -19,7 +19,10 @@
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<NDTScanMatcher>());
+  auto ndt_scan_matcher = std::make_shared<NDTScanMatcher>();
+  rclcpp::executors::MultiThreadedExecutor exec;
+  exec.add_node(ndt_scan_matcher);
+  exec.spin();
   rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
## Description
To execute callbackInitialPose in parallel with other callback function, the followings will be introduced after merging this PR.
* `MultiThreadedExecutor`
* Two callback group
  * one for callbackInitialPose ( `initial_pose_callback_group` )
  * the other for other callback functions ( `main_sub_opt.callback_group` )

## Review Procedure
Please check the following
* Successfully running Autoware with any rosbag file.
* Increased called count for `callbackInitialPose`

To count how many times `callbackInitialPose` is called, Perf is recommended to measure briefly.

Executing the following command during Autoware's running
```
perf stat -p `pgrep ndt` -- sleep 60
```
The following result is sample result which I got with Intel Xeon 2278GE, NVIDIA RTX2060S.

```
         14,636.55 msec task-clock                #    0.244 CPUs utilized          
           110,341      context-switches          #    0.008 M/sec                  
            33,486      cpu-migrations            #    0.002 M/sec                  
               463      page-faults               #    0.032 K/sec                  
    58,725,542,976      cycles                    #    4.012 GHz                    
    43,592,636,814      instructions              #    0.74  insn per cycle         
     5,436,256,860      branches                  #  371.417 M/sec                  
       189,192,223      branch-misses             #    3.48% of all branches  
```


## Remarks
This PR is same as https://github.com/tier4/autoware.iv/pull/2372


## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [pull request guidelines][pull-request-guidelines]
- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
