### PR TITLE
add unit to value side as well as other metrics.

### DIFF
--- a/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -268,9 +268,9 @@ void HDDMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
       stat.add(fmt::format("HDD {}: status", hdd_index), usage_dict_.at(level));
       stat.add(fmt::format("HDD {}: filesystem", hdd_index), list[0].c_str());
-      stat.add(fmt::format("HDD {}: size (MB)", hdd_index), list[1].c_str());
-      stat.add(fmt::format("HDD {}: used (MB)", hdd_index), list[2].c_str());
-      stat.add(fmt::format("HDD {}: avail (MB)", hdd_index), list[3].c_str());
+      stat.add(fmt::format("HDD {}: size", hdd_index), (list[1] + " MiB").c_str());
+      stat.add(fmt::format("HDD {}: used", hdd_index), (list[2] + " MiB").c_str());
+      stat.add(fmt::format("HDD {}: avail", hdd_index), (list[3] + " MiB").c_str());
       stat.add(fmt::format("HDD {}: use", hdd_index), list[4].c_str());
       std::string mounted_ = list[5];
       if (list.size() > 6) {


### PR DESCRIPTION
## Description

To align other metrics, unit (Mebibyte) would be added to value side instead of key.
It means that other metrics, like CPU Usage, are expressed with `12.34%`, which has a unit.
On the other hand, HDD volume metrics are expressed with only value like `245,678`, without `MiB`.

So, I think that adding unit to value is reasonable to align other metrics, like CPU usage, or GPU usage.

## Review Procedure
1. Run Autoware or system_monitor
2. Launch rqt_runtime_monitor
3. Check RuntimeMonitor

![rqt_runtime_monitor__RuntimeMonitor - rqt_001](https://user-images.githubusercontent.com/38586589/145619173-4c9eec64-236e-436f-8bad-6acd5ef6bff0.png)


## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [pull request guidelines][pull-request-guidelines]
- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
