### PR TITLE
Specify hdd device as mount point instead of dev file location

### DIFF
--- a/system/system_monitor/config/hdd_monitor.param.yaml
+++ b/system/system_monitor/config/hdd_monitor.param.yaml
@@ -4,7 +4,7 @@
     num_disks: 1
     disks: # Until multi type lists are allowed, name N the disks as disk0...disk{N-1}
       disk0:
-        name: /dev/sda3
+        name: /
         temp_warn: 55.0
         temp_error: 70.0
         free_warn: 5120 # MB(8hour)

--- a/system/system_monitor/include/system_monitor/hdd_monitor/hdd_monitor.hpp
+++ b/system/system_monitor/include/system_monitor/hdd_monitor/hdd_monitor.hpp
@@ -32,10 +32,11 @@
  */
 struct HDDParam
 {
-  float temp_warn_;   //!< @brief HDD temperature(DegC) to generate warning
-  float temp_error_;  //!< @brief HDD temperature(DegC) to generate error
-  int free_warn_;     //!< @brief HDD free space(MB) to generate warning
-  int free_error_;    //!< @brief HDD free space(MB) to generate error
+  std::string device_;  //!< @brief device
+  float temp_warn_;     //!< @brief HDD temperature(DegC) to generate warning
+  float temp_error_;    //!< @brief HDD temperature(DegC) to generate error
+  int free_warn_;       //!< @brief HDD free space(MB) to generate warning
+  int free_error_;      //!< @brief HDD free space(MB) to generate error
 
   HDDParam() : temp_warn_(55.0), temp_error_(70.0), free_warn_(5120), free_error_(100) {}
 };
@@ -85,6 +86,13 @@ protected:
    * @brief get HDD parameters
    */
   void getHDDParams();
+
+  /**
+   * @brief get device name from mount point
+   * @param [in] mount_point mount point
+   * @return device name
+   */
+  std::string getDeviceFromMountPoint(const std::string & mount_point);
 
   diagnostic_updater::Updater updater_;  //!< @brief Updater class which advertises to /diagnostics
 

--- a/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -156,8 +156,8 @@ void HDDMonitor::checkTemp(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   for (auto itr = hdd_params_.begin(); itr != hdd_params_.end(); ++itr, ++index) {
     // Retrieve HDD information
-    auto itrh = list.find(itr->second.device_);
-    if (itrh == list.end()) {
+    auto hdd_itr = list.find(itr->second.device_);
+    if (hdd_itr == list.end()) {
       stat.add(fmt::format("HDD {}: status", index), "hdd_reader error");
       stat.add(fmt::format("HDD {}: name", index), itr->first.c_str());
       stat.add(fmt::format("HDD {}: hdd_reader", index), strerror(ENOENT));
@@ -165,15 +165,15 @@ void HDDMonitor::checkTemp(diagnostic_updater::DiagnosticStatusWrapper & stat)
       continue;
     }
 
-    if (itrh->second.error_code_ != 0) {
+    if (hdd_itr->second.error_code_ != 0) {
       stat.add(fmt::format("HDD {}: status", index), "hdd_reader error");
       stat.add(fmt::format("HDD {}: name", index), itr->first.c_str());
-      stat.add(fmt::format("HDD {}: hdd_reader", index), strerror(itrh->second.error_code_));
+      stat.add(fmt::format("HDD {}: hdd_reader", index), strerror(hdd_itr->second.error_code_));
       error_str = "hdd_reader error";
       continue;
     }
 
-    float temp = static_cast<float>(itrh->second.temp_);
+    float temp = static_cast<float>(hdd_itr->second.temp_);
 
     level = DiagStatus::OK;
     if (temp >= itr->second.temp_error_) {
@@ -184,8 +184,8 @@ void HDDMonitor::checkTemp(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     stat.add(fmt::format("HDD {}: status", index), temp_dict_.at(level));
     stat.add(fmt::format("HDD {}: name", index), itr->second.device_.c_str());
-    stat.add(fmt::format("HDD {}: model", index), itrh->second.model_.c_str());
-    stat.add(fmt::format("HDD {}: serial", index), itrh->second.serial_.c_str());
+    stat.add(fmt::format("HDD {}: model", index), hdd_itr->second.model_.c_str());
+    stat.add(fmt::format("HDD {}: serial", index), hdd_itr->second.serial_.c_str());
     stat.addf(fmt::format("HDD {}: temperature", index), "%.1f DegC", temp);
 
     whole_level = std::max(whole_level, level);

--- a/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -348,5 +348,5 @@ std::string HDDMonitor::getDeviceFromMountPoint(const std::string & mount_point)
   return ret;
 }
 
-#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
+#include <rclcpp_components/register_node_macro.hpp>
 RCLCPP_COMPONENTS_REGISTER_NODE(HDDMonitor)

--- a/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -156,7 +156,7 @@ void HDDMonitor::checkTemp(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   for (auto itr = hdd_params_.begin(); itr != hdd_params_.end(); ++itr, ++index) {
     // Retrieve HDD information
-    auto itrh = list.find(itr->first);
+    auto itrh = list.find(itr->second.device_);
     if (itrh == list.end()) {
       stat.add(fmt::format("HDD {}: status", index), "hdd_reader error");
       stat.add(fmt::format("HDD {}: name", index), itr->first.c_str());
@@ -183,7 +183,7 @@ void HDDMonitor::checkTemp(diagnostic_updater::DiagnosticStatusWrapper & stat)
     }
 
     stat.add(fmt::format("HDD {}: status", index), temp_dict_.at(level));
-    stat.add(fmt::format("HDD {}: name", index), itr->first.c_str());
+    stat.add(fmt::format("HDD {}: name", index), itr->second.device_.c_str());
     stat.add(fmt::format("HDD {}: model", index), itrh->second.model_.c_str());
     stat.add(fmt::format("HDD {}: serial", index), itrh->second.serial_.c_str());
     stat.addf(fmt::format("HDD {}: temperature", index), "%.1f DegC", temp);
@@ -301,18 +301,52 @@ void HDDMonitor::getHDDParams()
   const auto num_disks = this->declare_parameter("num_disks", 0);
   for (auto i = 0; i < num_disks; ++i) {
     const auto prefix = "disks.disk" + std::to_string(i);
+    const auto name = declare_parameter<std::string>(prefix + ".name");
+
+    // Get device name from mount point
+    const auto device_name = getDeviceFromMountPoint(name);
+    if (device_name.empty()) {
+      continue;
+    }
+
     HDDParam param;
     param.temp_warn_ = declare_parameter<float>(prefix + ".temp_warn");
     param.temp_error_ = declare_parameter<float>(prefix + ".temp_error");
     param.free_warn_ = declare_parameter<int>(prefix + ".free_warn");
     param.free_error_ = declare_parameter<int>(prefix + ".free_error");
-    const auto name = declare_parameter<std::string>(prefix + ".name");
 
-    hdd_params_[name] = param;
+    // Remove index number for passing device name to hdd-reader
+    const std::regex pattern("\\d+$");
+    param.device_ = std::regex_replace(device_name, pattern, "");
+    hdd_params_[device_name] = param;
 
-    hdd_devices_.push_back(name);
+    hdd_devices_.push_back(param.device_);
   }
 }
 
-#include <rclcpp_components/register_node_macro.hpp>
+std::string HDDMonitor::getDeviceFromMountPoint(const std::string & mount_point)
+{
+  std::string ret;
+  bp::ipstream is_out;
+  bp::ipstream is_err;
+
+  bp::child c(
+    "/bin/sh", "-c", fmt::format("findmnt -n -o SOURCE {}", mount_point.c_str()),
+    bp::std_out > is_out, bp::std_err > is_err);
+  c.wait();
+
+  if (c.exit_code() != 0) {
+    RCLCPP_ERROR(get_logger(), "Failed to execute findmnt. %s", mount_point.c_str());
+    return "";
+  }
+
+  if (!std::getline(is_out, ret)) {
+    RCLCPP_ERROR(get_logger(), "Failed to find device name. %s", mount_point.c_str());
+    return "";
+  }
+
+  return ret;
+}
+
+#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
 RCLCPP_COMPONENTS_REGISTER_NODE(HDDMonitor)


### PR DESCRIPTION
## Description

The `hdd_monitor` mainly monitors hdd usage of system volume partition, and the dev file location depends on each environment.
This change will make `hdd_monitor` easier to configure without considering each environment by specifying mount point (such as `/`) to monitor hdd usage. 

## Review Procedure

Run system_monitor, and verify HDD Temperature and HDD Usage works correctly.
- HDD Temperature
![image](https://user-images.githubusercontent.com/57388357/145936418-2dee7e75-6782-435b-850e-273d9dfb4cb9.png)
- HDD Usage
![image](https://user-images.githubusercontent.com/57388357/145936591-17ee50ad-a7e7-4c84-94f4-9517b227e7c8.png)

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [pull request guidelines][pull-request-guidelines]
- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
