### PR TITLE
state_rviz_plugin: visualize selector mode and add disengage function

### DIFF
--- a/common/util/rviz_plugins/autoware_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/util/rviz_plugins/autoware_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -40,6 +40,15 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
   gate_layout->addWidget(gate_prefix_label_ptr);
   gate_layout->addWidget(gate_mode_label_ptr_);
 
+  // Selector Mode
+  auto * selector_prefix_label_ptr = new QLabel("SELECT: ");
+  selector_prefix_label_ptr->setAlignment(Qt::AlignRight);
+  selector_mode_label_ptr_ = new QLabel("INIT");
+  selector_mode_label_ptr_->setAlignment(Qt::AlignCenter);
+  auto * selector_layout = new QHBoxLayout;
+  selector_layout->addWidget(selector_prefix_label_ptr);
+  selector_layout->addWidget(selector_mode_label_ptr_);
+
   // State
   auto * state_prefix_label_ptr = new QLabel("STATE: ");
   state_prefix_label_ptr->setAlignment(Qt::AlignRight);
@@ -73,6 +82,7 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
 
   auto * v_layout = new QVBoxLayout;
   v_layout->addLayout(gate_layout);
+  v_layout->addLayout(selector_layout);
   v_layout->addLayout(state_layout);
   v_layout->addLayout(gear_layout);
   v_layout->addLayout(engage_status_layout);
@@ -86,6 +96,11 @@ void AutowareStatePanel::onInitialize()
 
   sub_gate_mode_ = raw_node_->create_subscription<autoware_control_msgs::msg::GateMode>(
     "/control/current_gate_mode", 10, std::bind(&AutowareStatePanel::onGateMode, this, _1));
+
+  sub_selector_mode_ =
+    raw_node_->create_subscription<autoware_control_msgs::msg::ExternalCommandSelectorMode>(
+      "/control/external_cmd_selector/current_selector_mode", 10,
+      std::bind(&AutowareStatePanel::onSelectorMode, this, _1));
 
   sub_autoware_state_ =
     raw_node_->create_subscription<autoware_auto_system_msgs::msg::AutowareState>(
@@ -117,6 +132,32 @@ void AutowareStatePanel::onGateMode(const autoware_control_msgs::msg::GateMode::
     default:
       gate_mode_label_ptr_->setText("UNKNOWN");
       gate_mode_label_ptr_->setStyleSheet("background-color: #FF0000;");
+      break;
+  }
+}
+
+void AutowareStatePanel::onSelectorMode(
+  const autoware_control_msgs::msg::ExternalCommandSelectorMode::ConstSharedPtr msg)
+{
+  switch (msg->data) {
+    case autoware_control_msgs::msg::ExternalCommandSelectorMode::REMOTE:
+      selector_mode_label_ptr_->setText("REMOTE");
+      selector_mode_label_ptr_->setStyleSheet("background-color: #00FF00;");
+      break;
+
+    case autoware_control_msgs::msg::ExternalCommandSelectorMode::LOCAL:
+      selector_mode_label_ptr_->setText("LOCAL");
+      selector_mode_label_ptr_->setStyleSheet("background-color: #FFFF00;");
+      break;
+
+    case autoware_control_msgs::msg::ExternalCommandSelectorMode::NONE:
+      selector_mode_label_ptr_->setText("NONE");
+      selector_mode_label_ptr_->setStyleSheet("background-color: #FF0000;");
+      break;
+
+    default:
+      selector_mode_label_ptr_->setText("UNKNOWN");
+      selector_mode_label_ptr_->setStyleSheet("background-color: #FF0000;");
       break;
   }
 }
@@ -170,13 +211,14 @@ void AutowareStatePanel::onShift(
 void AutowareStatePanel::onEngageStatus(
   const autoware_external_api_msgs::msg::EngageStatus::ConstSharedPtr msg)
 {
-  engage_status_label_ptr_->setText(QString::fromStdString(Bool2String(msg->engage)));
+  current_engage_ = msg->engage;
+  engage_status_label_ptr_->setText(QString::fromStdString(Bool2String(current_engage_)));
 }
 
 void AutowareStatePanel::onClickAutowareEngage()
 {
   auto req = std::make_shared<autoware_external_api_msgs::srv::Engage::Request>();
-  req->engage = true;
+  req->engage = current_engage_ ? false : true;
 
   RCLCPP_INFO(raw_node_->get_logger(), "client request");
 

--- a/common/util/rviz_plugins/autoware_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/util/rviz_plugins/autoware_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -24,6 +24,7 @@
 
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
+#include <autoware_control_msgs/msg/external_command_selector_mode.hpp>
 #include <autoware_control_msgs/msg/gate_mode.hpp>
 #include <autoware_external_api_msgs/msg/engage_status.hpp>
 #include <autoware_external_api_msgs/srv/engage.hpp>
@@ -43,12 +44,16 @@ public Q_SLOTS:
 
 protected:
   void onGateMode(const autoware_control_msgs::msg::GateMode::ConstSharedPtr msg);
+  void onSelectorMode(
+    const autoware_control_msgs::msg::ExternalCommandSelectorMode::ConstSharedPtr msg);
   void onAutowareState(const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr msg);
   void onShift(const autoware_auto_vehicle_msgs::msg::GearReport::ConstSharedPtr msg);
   void onEngageStatus(const autoware_external_api_msgs::msg::EngageStatus::ConstSharedPtr msg);
 
   rclcpp::Node::SharedPtr raw_node_;
   rclcpp::Subscription<autoware_control_msgs::msg::GateMode>::SharedPtr sub_gate_mode_;
+  rclcpp::Subscription<autoware_control_msgs::msg::ExternalCommandSelectorMode>::SharedPtr
+    sub_selector_mode_;
   rclcpp::Subscription<autoware_auto_system_msgs::msg::AutowareState>::SharedPtr
     sub_autoware_state_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::GearReport>::SharedPtr sub_gear_;
@@ -57,10 +62,13 @@ protected:
   rclcpp::Client<autoware_external_api_msgs::srv::Engage>::SharedPtr client_engage_;
 
   QLabel * gate_mode_label_ptr_;
+  QLabel * selector_mode_label_ptr_;
   QLabel * autoware_state_label_ptr_;
   QLabel * gear_label_ptr_;
   QLabel * engage_status_label_ptr_;
   QPushButton * engage_button_ptr_;
+
+  bool current_engage_;
 };
 
 }  // namespace rviz_plugins


### PR DESCRIPTION
## Description

https://github.com/tier4/autoware.iv/pull/2406 のポーティングPRです

## Review Procedure

変更内容が上記PRと同じであること

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [pull request guidelines][pull-request-guidelines]
- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
