### PR TITLE
Fix/behavior path drivable area

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/src/utilities.cpp
@@ -878,7 +878,9 @@ OccupancyGrid generateDrivableArea(
     const double yaw = tf2::getYaw(current_pose.pose.orientation);
     const double origin_offset_x_m = (-width / 4) * cos(yaw) - (-height / 2) * sin(yaw);
     const double origin_offset_y_m = (-width / 4) * sin(yaw) + (-height / 2) * cos(yaw);
-    grid_origin.pose.orientation = current_pose.pose.orientation;
+    // Only current yaw should be considered as the orientation of grid_origin.
+    grid_origin.pose.orientation =
+      autoware_utils::createQuaternionFromYaw(tf2::getYaw(current_pose.pose.orientation));
     grid_origin.pose.position.x = current_pose.pose.position.x + origin_offset_x_m;
     grid_origin.pose.position.y = current_pose.pose.position.y + origin_offset_y_m;
     grid_origin.pose.position.z = current_pose.pose.position.z;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/src/utilities.cpp
@@ -880,7 +880,7 @@ OccupancyGrid generateDrivableArea(
     const double origin_offset_y_m = (-width / 4) * sin(yaw) + (-height / 2) * cos(yaw);
     // Only current yaw should be considered as the orientation of grid_origin.
     grid_origin.pose.orientation =
-      autoware_utils::createQuaternionFromYaw(tf2::getYaw(current_pose.pose.orientation));
+      autoware_utils::createQuaternionFromYaw(yaw);
     grid_origin.pose.position.x = current_pose.pose.position.x + origin_offset_x_m;
     grid_origin.pose.position.y = current_pose.pose.position.y + origin_offset_y_m;
     grid_origin.pose.position.z = current_pose.pose.position.z;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/src/utilities.cpp
@@ -879,8 +879,7 @@ OccupancyGrid generateDrivableArea(
     const double origin_offset_x_m = (-width / 4) * cos(yaw) - (-height / 2) * sin(yaw);
     const double origin_offset_y_m = (-width / 4) * sin(yaw) + (-height / 2) * cos(yaw);
     // Only current yaw should be considered as the orientation of grid_origin.
-    grid_origin.pose.orientation =
-      autoware_utils::createQuaternionFromYaw(yaw);
+    grid_origin.pose.orientation = autoware_utils::createQuaternionFromYaw(yaw);
     grid_origin.pose.position.x = current_pose.pose.position.x + origin_offset_x_m;
     grid_origin.pose.position.y = current_pose.pose.position.y + origin_offset_y_m;
     grid_origin.pose.position.z = current_pose.pose.position.z;


### PR DESCRIPTION
## Description
- bug fix

Fix coordinate transformation of drivable area in behavior_path_planner. In some cases,  the position of dribable area shifted from the actual lanelets.

![image](https://user-images.githubusercontent.com/59680180/146757940-b0148abd-42ff-4bed-a238-d16e16bdbbee.png)

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
